### PR TITLE
Improves attribute documentation `note` formatting and reorganizes `examples`

### DIFF
--- a/Generator/Sources/FileRenderer.swift
+++ b/Generator/Sources/FileRenderer.swift
@@ -20,8 +20,8 @@ protocol FileRenderer {
 
 func renderDocs(_ attribute: Attribute) -> String {
     var result = "`\(attribute.id)`"
-    if let brief = attribute.brief {
-        result.append(": \(brief.replacingOccurrences(of: "\n", with: " "))")
+    if let brief = attribute.brief?.trimmingCharacters(in: .whitespacesAndNewlines), !brief.isEmpty {
+        result.append(": \(brief)")
     }
     result.append("\n\n- Stability: \(attribute.stability)")
 
@@ -29,8 +29,8 @@ func renderDocs(_ attribute: Attribute) -> String {
         result.append("\n\n- Type: enum")
         for member in attributeType.members {
             result.append("\n    - `\(member.value)`")
-            if let brief = member.brief {
-                result.append(": \(brief.trimmingCharacters(in: .whitespacesAndNewlines))")
+            if let brief = member.brief?.trimmingCharacters(in: .whitespacesAndNewlines), !brief.isEmpty {
+                result.append(": \(brief)")
             }
         }
     } else {

--- a/Generator/Sources/FileRenderer.swift
+++ b/Generator/Sources/FileRenderer.swift
@@ -37,8 +37,8 @@ func renderDocs(_ attribute: Attribute) -> String {
         result.append("\n\n- Type: \(attribute.type)")
     }
 
-    if let note = attribute.note {
-        result.append("\n\n\(note.replacingOccurrences(of: "\n", with: " "))")
+    if let note = attribute.note?.trimmingCharacters(in: .whitespacesAndNewlines), !note.isEmpty {
+        result.append("\n\n\(note)")
     }
 
     if let examples = attribute.examples {

--- a/Generator/Sources/FileRenderer.swift
+++ b/Generator/Sources/FileRenderer.swift
@@ -23,10 +23,10 @@ func renderDocs(_ attribute: Attribute) -> String {
     if let brief = attribute.brief?.trimmingCharacters(in: .whitespacesAndNewlines), !brief.isEmpty {
         result.append(": \(brief)")
     }
-    result.append("\n\n- Stability: \(attribute.stability)")
 
+    result.append("\n\n- Stability: \(attribute.stability)")
     if let attributeType = attribute.type as? Attribute.EnumType {
-        result.append("\n\n- Type: enum")
+        result.append("\n- Type: enum")
         for member in attributeType.members {
             result.append("\n    - `\(member.value)`")
             if let brief = member.brief?.trimmingCharacters(in: .whitespacesAndNewlines), !brief.isEmpty {
@@ -34,22 +34,21 @@ func renderDocs(_ attribute: Attribute) -> String {
             }
         }
     } else {
-        result.append("\n\n- Type: \(attribute.type)")
+        result.append("\n- Type: \(attribute.type)")
     }
-
-    if let note = attribute.note?.trimmingCharacters(in: .whitespacesAndNewlines), !note.isEmpty {
-        result.append("\n\n\(note)")
-    }
-
     if let examples = attribute.examples {
         if examples.count == 1 {
-            result.append("\n\n- Example: `\(examples[0])`")
+            result.append("\n- Example: `\(examples[0])`")
         } else {
-            result.append("\n\n- Examples:")
+            result.append("\n- Examples:")
             for example in examples {
                 result.append("\n    - `\(example)`")
             }
         }
+    }
+
+    if let note = attribute.note?.trimmingCharacters(in: .whitespacesAndNewlines), !note.isEmpty {
+        result.append("\n\n\(note)")
     }
 
     return result.prefixLines(with: "/// ")

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+client.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+client.swift
@@ -19,26 +19,22 @@ extension OTelAttribute {
         /// `client.address`: Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
-        /// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.
-        ///
         /// - Examples:
         ///     - `client.example.com`
         ///     - `10.1.2.80`
         ///     - `/tmp/my.sock`
+        ///
+        /// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.
         public static let address = "client.address"
 
         /// `client.port`: Client port number.
         ///
         /// - Stability: stable
-        ///
         /// - Type: int
+        /// - Example: `65123`
         ///
         /// When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries,  for example proxies, if it's available.
-        ///
-        /// - Example: `65123`
         public static let port = "client.port"
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+code.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+code.swift
@@ -58,7 +58,21 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples. The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in `code.stacktrace` without information on arguments.  Examples:  * Java method: `com.example.MyHttpService.serveRequest` * Java anonymous class method: `com.mycompany.Main$1.myMethod` * Java lambda method: `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod` * PHP function: `GuzzleHttp\Client::transfer` * Go function: `github.com/my/repo/pkg.foo.func5` * Elixir: `OpenTelemetry.Ctx.new` * Erlang: `opentelemetry_ctx:new` * Rust: `playground::my_module::my_cool_func` * C function: `fopen`
+            /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples.
+            /// The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in
+            /// `code.stacktrace` without information on arguments.
+            ///
+            /// Examples:
+            ///
+            /// * Java method: `com.example.MyHttpService.serveRequest`
+            /// * Java anonymous class method: `com.mycompany.Main$1.myMethod`
+            /// * Java lambda method: `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod`
+            /// * PHP function: `GuzzleHttp\Client::transfer`
+            /// * Go function: `github.com/my/repo/pkg.foo.func5`
+            /// * Elixir: `OpenTelemetry.Ctx.new`
+            /// * Erlang: `opentelemetry_ctx:new`
+            /// * Rust: `playground::my_module::my_cool_func`
+            /// * C function: `fopen`
             ///
             /// - Examples:
             ///     - `com.example.MyHttpService.serveRequest`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+code.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+code.swift
@@ -19,9 +19,7 @@ extension OTelAttribute {
         /// `code.stacktrace`: A stacktrace as a string in the natural representation for the language runtime. The representation is identical to [`exception.stacktrace`](/docs/exceptions/exceptions-spans.md#stacktrace-representation). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Location'. This constraint is imposed to prevent redundancy and maintain data integrity.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Example: `at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
         /// `
         public static let stacktrace = "code.stacktrace"
@@ -31,9 +29,7 @@ extension OTelAttribute {
             /// `code.column.number`: The column number in `code.file.path` best representing the operation. It SHOULD point within the code unit named in `code.function.name`. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Line'. This constraint is imposed to prevent redundancy and maintain data integrity.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
             /// - Example: `16`
             public static let number = "code.column.number"
         }
@@ -43,9 +39,7 @@ extension OTelAttribute {
             /// `code.file.path`: The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `/usr/local/MyApplication/content_root/app/index.php`
             public static let path = "code.file.path"
         }
@@ -55,8 +49,11 @@ extension OTelAttribute {
             /// `code.function.name`: The method or function fully-qualified name without arguments. The value should fit the natural representation of the language runtime, which is also likely the same used within `code.stacktrace` attribute value. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `com.example.MyHttpService.serveRequest`
+            ///     - `GuzzleHttp\Client::transfer`
+            ///     - `fopen`
             ///
             /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples.
             /// The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in
@@ -73,11 +70,6 @@ extension OTelAttribute {
             /// * Erlang: `opentelemetry_ctx:new`
             /// * Rust: `playground::my_module::my_cool_func`
             /// * C function: `fopen`
-            ///
-            /// - Examples:
-            ///     - `com.example.MyHttpService.serveRequest`
-            ///     - `GuzzleHttp\Client::transfer`
-            ///     - `fopen`
             public static let name = "code.function.name"
         }
 
@@ -86,9 +78,7 @@ extension OTelAttribute {
             /// `code.line.number`: The line number in `code.file.path` best representing the operation. It SHOULD point within the code unit named in `code.function.name`. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Line'. This constraint is imposed to prevent redundancy and maintain data integrity.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
             /// - Example: `42`
             public static let number = "code.line.number"
         }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+db.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+db.swift
@@ -22,7 +22,9 @@ extension OTelAttribute {
         ///
         /// - Type: string
         ///
-        /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted. Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system. It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
+        /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted.
+        /// Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
+        /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
         ///
         /// - Examples:
         ///     - `customers`
@@ -37,7 +39,15 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  The collection name SHOULD NOT be extracted from `db.query.text`, when the database system supports query text with multiple collections in non-batch operations.  For batch operations, if the individual operations are known to have the same collection name then that collection name SHOULD be used.
+            /// It is RECOMMENDED to capture the value as provided by the application
+            /// without attempting to do any case normalization.
+            ///
+            /// The collection name SHOULD NOT be extracted from `db.query.text`,
+            /// when the database system supports query text with multiple collections
+            /// in non-batch operations.
+            ///
+            /// For batch operations, if the individual operations are known to have the same
+            /// collection name then that collection name SHOULD be used.
             ///
             /// - Examples:
             ///     - `public.users`
@@ -53,7 +63,20 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  The operation name SHOULD NOT be extracted from `db.query.text`, when the database system supports query text with multiple operations in non-batch operations.  If spaces can occur in the operation name, multiple consecutive spaces SHOULD be normalized to a single space.  For batch operations, if the individual operations are known to have the same operation name then that operation name SHOULD be used prepended by `BATCH `, otherwise `db.operation.name` SHOULD be `BATCH` or some other database system specific term if more applicable.
+            /// It is RECOMMENDED to capture the value as provided by the application
+            /// without attempting to do any case normalization.
+            ///
+            /// The operation name SHOULD NOT be extracted from `db.query.text`,
+            /// when the database system supports query text with multiple operations
+            /// in non-batch operations.
+            ///
+            /// If spaces can occur in the operation name, multiple consecutive spaces
+            /// SHOULD be normalized to a single space.
+            ///
+            /// For batch operations, if the individual operations are known to have the same operation name
+            /// then that operation name SHOULD be used prepended by `BATCH `,
+            /// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
+            /// system specific term if more applicable.
             ///
             /// - Examples:
             ///     - `findAndModify`
@@ -87,7 +110,15 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// The query summary describes a class of database queries and is useful as a grouping key, especially when analyzing telemetry for database calls involving complex queries.  Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing SHOULD generate a summary following [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query) section.
+            /// The query summary describes a class of database queries and is useful
+            /// as a grouping key, especially when analyzing telemetry for database
+            /// calls involving complex queries.
+            ///
+            /// Summary may be available to the instrumentation through
+            /// instrumentation hooks or other means. If it is not available, instrumentations
+            /// that support query parsing SHOULD generate a summary following
+            /// [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query)
+            /// section.
             ///
             /// - Examples:
             ///     - `SELECT wuser_table`
@@ -101,7 +132,9 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext). For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable. Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
+            /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext).
+            /// For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
+            /// Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
             ///
             /// - Examples:
             ///     - `SELECT * FROM wuser_table where username = ?`
@@ -117,7 +150,8 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes. Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
+            /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
+            /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
             ///
             /// - Examples:
             ///     - `102`
@@ -135,7 +169,11 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  For batch operations, if the individual operations are known to have the same stored procedure name then that stored procedure name SHOULD be used.
+            /// It is RECOMMENDED to capture the value as provided by the application
+            /// without attempting to do any case normalization.
+            ///
+            /// For batch operations, if the individual operations are known to have the same
+            /// stored procedure name then that stored procedure name SHOULD be used.
             ///
             /// - Example: `GetCustomer`
             public static let name = "db.stored_procedure.name"

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+db.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+db.swift
@@ -19,16 +19,14 @@ extension OTelAttribute {
         /// `db.namespace`: The name of the database, fully qualified within the server address and port.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
+        /// - Examples:
+        ///     - `customers`
+        ///     - `test.users`
         ///
         /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted.
         /// Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
         /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
-        ///
-        /// - Examples:
-        ///     - `customers`
-        ///     - `test.users`
         public static let namespace = "db.namespace"
 
         /// `db.collection` namespace
@@ -36,8 +34,10 @@ extension OTelAttribute {
             /// `db.collection.name`: The name of a collection (table, container) within the database.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `public.users`
+            ///     - `customers`
             ///
             /// It is RECOMMENDED to capture the value as provided by the application
             /// without attempting to do any case normalization.
@@ -48,10 +48,6 @@ extension OTelAttribute {
             ///
             /// For batch operations, if the individual operations are known to have the same
             /// collection name then that collection name SHOULD be used.
-            ///
-            /// - Examples:
-            ///     - `public.users`
-            ///     - `customers`
             public static let name = "db.collection.name"
         }
 
@@ -60,8 +56,11 @@ extension OTelAttribute {
             /// `db.operation.name`: The name of the operation or command being executed.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `findAndModify`
+            ///     - `HMSET`
+            ///     - `SELECT`
             ///
             /// It is RECOMMENDED to capture the value as provided by the application
             /// without attempting to do any case normalization.
@@ -77,11 +76,6 @@ extension OTelAttribute {
             /// then that operation name SHOULD be used prepended by `BATCH `,
             /// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
             /// system specific term if more applicable.
-            ///
-            /// - Examples:
-            ///     - `findAndModify`
-            ///     - `HMSET`
-            ///     - `SELECT`
             public static let name = "db.operation.name"
 
             /// `db.operation.batch` namespace
@@ -89,15 +83,13 @@ extension OTelAttribute {
                 /// `db.operation.batch.size`: The number of queries included in a batch operation.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
-                /// Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` SHOULD never be `1`.
-                ///
                 /// - Examples:
                 ///     - `2`
                 ///     - `3`
                 ///     - `4`
+                ///
+                /// Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` SHOULD never be `1`.
                 public static let size = "db.operation.batch.size"
             }
         }
@@ -107,8 +99,11 @@ extension OTelAttribute {
             /// `db.query.summary`: Low cardinality summary of a database query.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `SELECT wuser_table`
+            ///     - `INSERT shipping_details SELECT orders`
+            ///     - `get user by id`
             ///
             /// The query summary describes a class of database queries and is useful
             /// as a grouping key, especially when analyzing telemetry for database
@@ -119,26 +114,19 @@ extension OTelAttribute {
             /// that support query parsing SHOULD generate a summary following
             /// [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query)
             /// section.
-            ///
-            /// - Examples:
-            ///     - `SELECT wuser_table`
-            ///     - `INSERT shipping_details SELECT orders`
-            ///     - `get user by id`
             public static let summary = "db.query.summary"
 
             /// `db.query.text`: The database query being executed.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `SELECT * FROM wuser_table where username = ?`
+            ///     - `SET mykey ?`
             ///
             /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext).
             /// For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
             /// Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
-            ///
-            /// - Examples:
-            ///     - `SELECT * FROM wuser_table where username = ?`
-            ///     - `SET mykey ?`
             public static let text = "db.query.text"
         }
 
@@ -147,17 +135,15 @@ extension OTelAttribute {
             /// `db.response.status_code`: Database response status code.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
-            /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
-            ///
             /// - Examples:
             ///     - `102`
             ///     - `ORA-17002`
             ///     - `08P01`
             ///     - `404`
+            ///
+            /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
+            /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
             public static let statusCode = "db.response.status_code"
         }
 
@@ -166,16 +152,14 @@ extension OTelAttribute {
             /// `db.stored_procedure.name`: The name of a stored procedure within the database.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Example: `GetCustomer`
             ///
             /// It is RECOMMENDED to capture the value as provided by the application
             /// without attempting to do any case normalization.
             ///
             /// For batch operations, if the individual operations are known to have the same
             /// stored procedure name then that stored procedure name SHOULD be used.
-            ///
-            /// - Example: `GetCustomer`
             public static let name = "db.stored_procedure.name"
         }
 
@@ -184,7 +168,6 @@ extension OTelAttribute {
             /// `db.system.name`: The database management system (DBMS) product as identified by the client instrumentation.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `other_sql`: Some other SQL database. Fallback only.
             ///     - `softwareag.adabas`: [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas)

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+error.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+error.swift
@@ -19,9 +19,13 @@ extension OTelAttribute {
         /// `error.type`: Describes a class of error the operation ended with.
         ///
         /// - Stability: stable
-        ///
         /// - Type: enum
         ///     - `_OTHER`: A fallback error value to be used when the instrumentation doesn't define a custom value.
+        /// - Examples:
+        ///     - `timeout`
+        ///     - `java.net.UnknownHostException`
+        ///     - `server_certificate_invalid`
+        ///     - `500`
         ///
         /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
         ///
@@ -42,12 +46,6 @@ extension OTelAttribute {
         ///
         /// - Use a domain-specific attribute
         /// - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
-        ///
-        /// - Examples:
-        ///     - `timeout`
-        ///     - `java.net.UnknownHostException`
-        ///     - `server_certificate_invalid`
-        ///     - `500`
         public static let `type` = "error.type"
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+error.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+error.swift
@@ -23,7 +23,25 @@ extension OTelAttribute {
         /// - Type: enum
         ///     - `_OTHER`: A fallback error value to be used when the instrumentation doesn't define a custom value.
         ///
-        /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.  When `error.type` is set to a type (e.g., an exception type), its canonical class name identifying the type within the artifact SHOULD be used.  Instrumentations SHOULD document the list of errors they report.  The cardinality of `error.type` within one instrumentation library SHOULD be low. Telemetry consumers that aggregate data from multiple instrumentation libraries and applications should be prepared for `error.type` to have high cardinality at query time when no additional filters are applied.  If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.  If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes), it's RECOMMENDED to:  - Use a domain-specific attribute - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+        /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+        ///
+        /// When `error.type` is set to a type (e.g., an exception type), its
+        /// canonical class name identifying the type within the artifact SHOULD be used.
+        ///
+        /// Instrumentations SHOULD document the list of errors they report.
+        ///
+        /// The cardinality of `error.type` within one instrumentation library SHOULD be low.
+        /// Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+        /// should be prepared for `error.type` to have high cardinality at query time when no
+        /// additional filters are applied.
+        ///
+        /// If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+        ///
+        /// If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+        /// it's RECOMMENDED to:
+        ///
+        /// - Use a domain-specific attribute
+        /// - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
         ///
         /// - Examples:
         ///     - `timeout`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+exception.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+exception.swift
@@ -19,7 +19,6 @@ extension OTelAttribute {
         /// `exception.escaped`: Indicates that the exception is escaping the scope of the span.
         ///
         /// - Stability: stable
-        ///
         /// - Type: boolean
         @available(
             *,
@@ -32,9 +31,7 @@ extension OTelAttribute {
         /// `exception.message`: The exception message.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Examples:
         ///     - `Division by zero`
         ///     - `Can't convert 'int' object to str implicitly`
@@ -43,9 +40,7 @@ extension OTelAttribute {
         /// `exception.stacktrace`: A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Example: `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
         /// `
         public static let stacktrace = "exception.stacktrace"
@@ -53,9 +48,7 @@ extension OTelAttribute {
         /// `exception.type`: The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Examples:
         ///     - `java.net.ConnectException`
         ///     - `OSError`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+http.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+http.swift
@@ -19,15 +19,13 @@ extension OTelAttribute {
         /// `http.route`: The matched route, that is, the path template in the format used by the respective server framework.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
-        /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-        /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-        ///
         /// - Examples:
         ///     - `/users/:userID?`
         ///     - `{controller}/{action}/{id?}`
+        ///
+        /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+        /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
         public static let route = "http.route"
 
         /// `http.request` namespace
@@ -35,7 +33,6 @@ extension OTelAttribute {
             /// `http.request.header`: HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
             ///
             /// - Stability: stable
-            ///
             /// - Type: templateStringArray
             ///
             /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
@@ -59,7 +56,6 @@ extension OTelAttribute {
             /// `http.request.method`: HTTP request method.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `CONNECT`: CONNECT method.
             ///     - `DELETE`: DELETE method.
@@ -71,6 +67,10 @@ extension OTelAttribute {
             ///     - `PUT`: PUT method.
             ///     - `TRACE`: TRACE method.
             ///     - `_OTHER`: Any HTTP method that the instrumentation has no prior knowledge of.
+            /// - Examples:
+            ///     - `GET`
+            ///     - `POST`
+            ///     - `HEAD`
             ///
             /// HTTP request method value SHOULD be "known" to the instrumentation.
             /// By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -86,19 +86,12 @@ extension OTelAttribute {
             /// HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
             /// Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
             /// Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-            ///
-            /// - Examples:
-            ///     - `GET`
-            ///     - `POST`
-            ///     - `HEAD`
             public static let method = "http.request.method"
 
             /// `http.request.method_original`: Original HTTP method sent by the client in the request line.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `GeT`
             ///     - `ACL`
@@ -108,12 +101,10 @@ extension OTelAttribute {
             /// `http.request.resend_count`: The ordinal number of request resending attempt (for any reason, including redirects).
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
+            /// - Example: `3`
             ///
             /// The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-            ///
-            /// - Example: `3`
             public static let resendCount = "http.request.resend_count"
         }
 
@@ -122,7 +113,6 @@ extension OTelAttribute {
             /// `http.response.header`: HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
             ///
             /// - Stability: stable
-            ///
             /// - Type: templateStringArray
             ///
             /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
@@ -145,9 +135,7 @@ extension OTelAttribute {
             /// `http.response.status_code`: [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
             /// - Example: `200`
             public static let statusCode = "http.response.status_code"
         }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+http.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+http.swift
@@ -22,7 +22,8 @@ extension OTelAttribute {
         ///
         /// - Type: string
         ///
-        /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it. SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
+        /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+        /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
         ///
         /// - Examples:
         ///     - `/users/:userID?`
@@ -37,7 +38,22 @@ extension OTelAttribute {
             ///
             /// - Type: templateStringArray
             ///
-            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information.  The `User-Agent` header is already captured in the `user_agent.original` attribute. Users MAY explicitly configure instrumentations to capture them even though it is not recommended.  The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.  Examples:  - A header `Content-Type: application/json` SHOULD be recorded as the `http.request.header.content-type`   attribute with value `["application/json"]`. - A header `X-Forwarded-For: 1.2.3.4, 1.2.3.5` SHOULD be recorded as the `http.request.header.x-forwarded-for`   attribute with value `["1.2.3.4", "1.2.3.5"]` or `["1.2.3.4, 1.2.3.5"]` depending on the HTTP library.
+            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
+            /// Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+            ///
+            /// The `User-Agent` header is already captured in the `user_agent.original` attribute.
+            /// Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
+            ///
+            /// The attribute value MUST consist of either multiple header values as an array of strings
+            /// or a single-item array containing a possibly comma-concatenated string, depending on the way
+            /// the HTTP library provides access to headers.
+            ///
+            /// Examples:
+            ///
+            /// - A header `Content-Type: application/json` SHOULD be recorded as the `http.request.header.content-type`
+            ///   attribute with value `["application/json"]`.
+            /// - A header `X-Forwarded-For: 1.2.3.4, 1.2.3.5` SHOULD be recorded as the `http.request.header.x-forwarded-for`
+            ///   attribute with value `["1.2.3.4", "1.2.3.5"]` or `["1.2.3.4, 1.2.3.5"]` depending on the HTTP library.
             public static let header = "http.request.header"
 
             /// `http.request.method`: HTTP request method.
@@ -56,7 +72,20 @@ extension OTelAttribute {
             ///     - `TRACE`: TRACE method.
             ///     - `_OTHER`: Any HTTP method that the instrumentation has no prior knowledge of.
             ///
-            /// HTTP request method value SHOULD be "known" to the instrumentation. By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods) and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).  If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.  If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).  HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly. Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent. Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+            /// HTTP request method value SHOULD be "known" to the instrumentation.
+            /// By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+            /// and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+            ///
+            /// If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+            ///
+            /// If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+            /// the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+            /// OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+            /// (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+            ///
+            /// HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+            /// Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+            /// Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
             ///
             /// - Examples:
             ///     - `GET`
@@ -96,7 +125,21 @@ extension OTelAttribute {
             ///
             /// - Type: templateStringArray
             ///
-            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.  Users MAY explicitly configure instrumentations to capture them even though it is not recommended.  The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.  Examples:  - A header `Content-Type: application/json` header SHOULD be recorded as the `http.request.response.content-type`   attribute with value `["application/json"]`. - A header `My-custom-header: abc, def` header SHOULD be recorded as the `http.response.header.my-custom-header`   attribute with value `["abc", "def"]` or `["abc, def"]` depending on the HTTP library.
+            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
+            /// Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+            ///
+            /// Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
+            ///
+            /// The attribute value MUST consist of either multiple header values as an array of strings
+            /// or a single-item array containing a possibly comma-concatenated string, depending on the way
+            /// the HTTP library provides access to headers.
+            ///
+            /// Examples:
+            ///
+            /// - A header `Content-Type: application/json` header SHOULD be recorded as the `http.request.response.content-type`
+            ///   attribute with value `["application/json"]`.
+            /// - A header `My-custom-header: abc, def` header SHOULD be recorded as the `http.response.header.my-custom-header`
+            ///   attribute with value `["abc", "def"]` or `["abc, def"]` depending on the HTTP library.
             public static let header = "http.response.header"
 
             /// `http.response.status_code`: [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+network.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+network.swift
@@ -19,38 +19,34 @@ extension OTelAttribute {
         /// `network.transport`: [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication).
         ///
         /// - Stability: stable
-        ///
         /// - Type: enum
         ///     - `tcp`: TCP
         ///     - `udp`: UDP
         ///     - `pipe`: Named or anonymous pipe.
         ///     - `unix`: Unix domain socket
         ///     - `quic`: QUIC
+        /// - Examples:
+        ///     - `tcp`
+        ///     - `udp`
         ///
         /// The value SHOULD be normalized to lowercase.
         ///
         /// Consider always setting the transport when setting a port number, since
         /// a port number is ambiguous without knowing the transport. For example
         /// different processes could be listening on TCP port 12345 and UDP port 12345.
-        ///
-        /// - Examples:
-        ///     - `tcp`
-        ///     - `udp`
         public static let transport = "network.transport"
 
         /// `network.type`: [OSI network layer](https://wikipedia.org/wiki/Network_layer) or non-OSI equivalent.
         ///
         /// - Stability: stable
-        ///
         /// - Type: enum
         ///     - `ipv4`: IPv4
         ///     - `ipv6`: IPv6
-        ///
-        /// The value SHOULD be normalized to lowercase.
-        ///
         /// - Examples:
         ///     - `ipv4`
         ///     - `ipv6`
+        ///
+        /// The value SHOULD be normalized to lowercase.
         public static let `type` = "network.type"
 
         /// `network.local` namespace
@@ -58,9 +54,7 @@ extension OTelAttribute {
             /// `network.local.address`: Local address of the network connection - IP address or Unix domain socket name.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `10.1.2.80`
             ///     - `/tmp/my.sock`
@@ -69,9 +63,7 @@ extension OTelAttribute {
             /// `network.local.port`: Local port number of the network connection.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
             /// - Example: `65123`
             public static let port = "network.local.port"
         }
@@ -81,9 +73,7 @@ extension OTelAttribute {
             /// `network.peer.address`: Peer address of the network connection - IP address or Unix domain socket name.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `10.1.2.80`
             ///     - `/tmp/my.sock`
@@ -92,9 +82,7 @@ extension OTelAttribute {
             /// `network.peer.port`: Peer port number of the network connection.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
             /// - Example: `65123`
             public static let port = "network.peer.port"
         }
@@ -104,28 +92,24 @@ extension OTelAttribute {
             /// `network.protocol.name`: [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// The value SHOULD be normalized to lowercase.
-            ///
             /// - Examples:
             ///     - `amqp`
             ///     - `http`
             ///     - `mqtt`
+            ///
+            /// The value SHOULD be normalized to lowercase.
             public static let name = "network.protocol.name"
 
             /// `network.protocol.version`: The actual version of the protocol used for network communication.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
-            ///
             /// - Examples:
             ///     - `1.1`
             ///     - `2`
+            ///
+            /// If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
             public static let version = "network.protocol.version"
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+network.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+network.swift
@@ -27,7 +27,11 @@ extension OTelAttribute {
         ///     - `unix`: Unix domain socket
         ///     - `quic`: QUIC
         ///
-        /// The value SHOULD be normalized to lowercase.  Consider always setting the transport when setting a port number, since a port number is ambiguous without knowing the transport. For example different processes could be listening on TCP port 12345 and UDP port 12345.
+        /// The value SHOULD be normalized to lowercase.
+        ///
+        /// Consider always setting the transport when setting a port number, since
+        /// a port number is ambiguous without knowing the transport. For example
+        /// different processes could be listening on TCP port 12345 and UDP port 12345.
         ///
         /// - Examples:
         ///     - `tcp`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+otel.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+otel.swift
@@ -19,7 +19,6 @@ extension OTelAttribute {
         /// `otel.status_code`: Name of the code, either "OK" or "ERROR". MUST NOT be set if the status code is UNSET.
         ///
         /// - Stability: stable
-        ///
         /// - Type: enum
         ///     - `OK`: The operation has been validated by an Application developer or Operator to have completed successfully.
         ///     - `ERROR`: The operation contains an error.
@@ -28,9 +27,7 @@ extension OTelAttribute {
         /// `otel.status_description`: Description of the Status if it has a value, otherwise not set.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Example: `resource not found`
         public static let statusDescription = "otel.status_description"
 
@@ -39,18 +36,14 @@ extension OTelAttribute {
             /// `otel.scope.name`: The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `io.opentelemetry.contrib.mongodb`
             public static let name = "otel.scope.name"
 
             /// `otel.scope.version`: The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `1.0.0`
             public static let version = "otel.scope.version"
         }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+server.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+server.swift
@@ -19,29 +19,25 @@ extension OTelAttribute {
         /// `server.address`: Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
-        /// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
-        ///
         /// - Examples:
         ///     - `example.com`
         ///     - `10.1.2.80`
         ///     - `/tmp/my.sock`
+        ///
+        /// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
         public static let address = "server.address"
 
         /// `server.port`: Server port number.
         ///
         /// - Stability: stable
-        ///
         /// - Type: int
-        ///
-        /// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-        ///
         /// - Examples:
         ///     - `80`
         ///     - `8080`
         ///     - `443`
+        ///
+        /// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
         public static let port = "server.port"
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+service.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+service.swift
@@ -19,20 +19,16 @@ extension OTelAttribute {
         /// `service.name`: Logical name of the service.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
+        /// - Example: `shoppingcart`
         ///
         /// MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-        ///
-        /// - Example: `shoppingcart`
         public static let name = "service.name"
 
         /// `service.version`: The version string of the service API or implementation. The format is not defined by these conventions.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Examples:
         ///     - `2.0.0`
         ///     - `a01dbef8a`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+telemetry.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+telemetry.swift
@@ -21,7 +21,6 @@ extension OTelAttribute {
             /// `telemetry.sdk.language`: The language of the telemetry SDK.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `cpp`
             ///     - `dotnet`
@@ -40,8 +39,8 @@ extension OTelAttribute {
             /// `telemetry.sdk.name`: The name of the telemetry SDK as defined above.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Example: `opentelemetry`
             ///
             /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
             /// If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
@@ -49,16 +48,12 @@ extension OTelAttribute {
             /// or another suitable identifier depending on the language.
             /// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
             /// All custom identifiers SHOULD be stable across different versions of an implementation.
-            ///
-            /// - Example: `opentelemetry`
             public static let name = "telemetry.sdk.name"
 
             /// `telemetry.sdk.version`: The version string of the telemetry SDK.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `1.2.3`
             public static let version = "telemetry.sdk.version"
         }

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+telemetry.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+telemetry.swift
@@ -43,7 +43,12 @@ extension OTelAttribute {
             ///
             /// - Type: string
             ///
-            /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`. If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point or another suitable identifier depending on the language. The identifier `opentelemetry` is reserved and MUST NOT be used in this case. All custom identifiers SHOULD be stable across different versions of an implementation.
+            /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
+            /// If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
+            /// `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point
+            /// or another suitable identifier depending on the language.
+            /// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
+            /// All custom identifiers SHOULD be stable across different versions of an implementation.
             ///
             /// - Example: `opentelemetry`
             public static let name = "telemetry.sdk.name"

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+url.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+url.swift
@@ -31,7 +31,29 @@ extension OTelAttribute {
         ///
         /// - Type: string
         ///
-        /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.  `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.  `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed).  Sensitive content provided in `url.full` SHOULD be scrubbed when instrumentations can identify it.  ![Development](https://img.shields.io/badge/-development-blue) Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:  * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token) * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)  This list is subject to change over time.  When a query string value is redacted, the query string key SHOULD still be preserved, e.g. `https://www.example.com/path?color=blue&sig=REDACTED`.
+        /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
+        /// is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
+        ///
+        /// `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
+        /// In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
+        ///
+        /// `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed).
+        ///
+        /// Sensitive content provided in `url.full` SHOULD be scrubbed when instrumentations can identify it.
+        ///
+        /// ![Development](https://img.shields.io/badge/-development-blue)
+        /// Query string values for the following keys SHOULD be redacted by default and replaced by the
+        /// value `REDACTED`:
+        ///
+        /// * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+        /// * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+        /// * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
+        /// * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+        ///
+        /// This list is subject to change over time.
+        ///
+        /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
+        /// `https://www.example.com/path?color=blue&sig=REDACTED`.
         ///
         /// - Examples:
         ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
@@ -55,7 +77,20 @@ extension OTelAttribute {
         ///
         /// - Type: string
         ///
-        /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.  ![Development](https://img.shields.io/badge/-development-blue) Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:  * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token) * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)  This list is subject to change over time.  When a query string value is redacted, the query string key SHOULD still be preserved, e.g. `q=OpenTelemetry&sig=REDACTED`.
+        /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.
+        ///
+        /// ![Development](https://img.shields.io/badge/-development-blue)
+        /// Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:
+        ///
+        /// * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+        /// * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+        /// * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
+        /// * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+        ///
+        /// This list is subject to change over time.
+        ///
+        /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
+        /// `q=OpenTelemetry&sig=REDACTED`.
         ///
         /// - Example: `q=OpenTelemetry`
         public static let query = "url.query"

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+url.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+url.swift
@@ -19,17 +19,17 @@ extension OTelAttribute {
         /// `url.fragment`: The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Example: `SemConv`
         public static let fragment = "url.fragment"
 
         /// `url.full`: Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
+        /// - Examples:
+        ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
+        ///     - `//localhost`
         ///
         /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
         /// is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
@@ -54,28 +54,22 @@ extension OTelAttribute {
         ///
         /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
         /// `https://www.example.com/path?color=blue&sig=REDACTED`.
-        ///
-        /// - Examples:
-        ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
-        ///     - `//localhost`
         public static let full = "url.full"
 
         /// `url.path`: The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
+        /// - Example: `/search`
         ///
         /// Sensitive content provided in `url.path` SHOULD be scrubbed when instrumentations can identify it.
-        ///
-        /// - Example: `/search`
         public static let path = "url.path"
 
         /// `url.query`: The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
+        /// - Example: `q=OpenTelemetry`
         ///
         /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.
         ///
@@ -91,16 +85,12 @@ extension OTelAttribute {
         ///
         /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
         /// `q=OpenTelemetry&sig=REDACTED`.
-        ///
-        /// - Example: `q=OpenTelemetry`
         public static let query = "url.query"
 
         /// `url.scheme`: The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Examples:
         ///     - `https`
         ///     - `ftp`

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+userAgent.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+userAgent.swift
@@ -19,9 +19,7 @@ extension OTelAttribute {
         /// `user_agent.original`: Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client.
         ///
         /// - Stability: stable
-        ///
         /// - Type: string
-        ///
         /// - Examples:
         ///     - `CERN-LineMode/2.15 libwww/2.17b3`
         ///     - `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+client.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+client.swift
@@ -42,26 +42,22 @@ extension SpanAttributes {
             /// `client.address`: Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.
-            ///
             /// - Examples:
             ///     - `client.example.com`
             ///     - `10.1.2.80`
             ///     - `/tmp/my.sock`
+            ///
+            /// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.
             public var address: Self.Key<String> { .init(name: OTelAttribute.client.address) }
 
             /// `client.port`: Client port number.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
+            /// - Example: `65123`
             ///
             /// When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries,  for example proxies, if it's available.
-            ///
-            /// - Example: `65123`
             public var port: Self.Key<Int> { .init(name: OTelAttribute.client.port) }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
@@ -42,9 +42,7 @@ extension SpanAttributes {
             /// `code.stacktrace`: A stacktrace as a string in the natural representation for the language runtime. The representation is identical to [`exception.stacktrace`](/docs/exceptions/exceptions-spans.md#stacktrace-representation). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Location'. This constraint is imposed to prevent redundancy and maintain data integrity.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
             /// `
             public var stacktrace: Self.Key<String> { .init(name: OTelAttribute.code.stacktrace) }
@@ -74,9 +72,7 @@ extension SpanAttributes {
                 /// `code.column.number`: The column number in `code.file.path` best representing the operation. It SHOULD point within the code unit named in `code.function.name`. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Line'. This constraint is imposed to prevent redundancy and maintain data integrity.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
                 /// - Example: `16`
                 public var number: Self.Key<Int> { .init(name: OTelAttribute.code.column.number) }
             }
@@ -106,9 +102,7 @@ extension SpanAttributes {
                 /// `code.file.path`: The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Example: `/usr/local/MyApplication/content_root/app/index.php`
                 public var path: Self.Key<String> { .init(name: OTelAttribute.code.file.path) }
             }
@@ -138,8 +132,11 @@ extension SpanAttributes {
                 /// `code.function.name`: The method or function fully-qualified name without arguments. The value should fit the natural representation of the language runtime, which is also likely the same used within `code.stacktrace` attribute value. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Function'. This constraint is imposed to prevent redundancy and maintain data integrity.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Examples:
+                ///     - `com.example.MyHttpService.serveRequest`
+                ///     - `GuzzleHttp\Client::transfer`
+                ///     - `fopen`
                 ///
                 /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples.
                 /// The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in
@@ -156,11 +153,6 @@ extension SpanAttributes {
                 /// * Erlang: `opentelemetry_ctx:new`
                 /// * Rust: `playground::my_module::my_cool_func`
                 /// * C function: `fopen`
-                ///
-                /// - Examples:
-                ///     - `com.example.MyHttpService.serveRequest`
-                ///     - `GuzzleHttp\Client::transfer`
-                ///     - `fopen`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.code.function.name) }
             }
         }
@@ -189,9 +181,7 @@ extension SpanAttributes {
                 /// `code.line.number`: The line number in `code.file.path` best representing the operation. It SHOULD point within the code unit named in `code.function.name`. This attribute MUST NOT be used on the Profile signal since the data is already captured in 'message Line'. This constraint is imposed to prevent redundancy and maintain data integrity.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
                 /// - Example: `42`
                 public var number: Self.Key<Int> { .init(name: OTelAttribute.code.line.number) }
             }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
@@ -141,7 +141,21 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples. The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in `code.stacktrace` without information on arguments.  Examples:  * Java method: `com.example.MyHttpService.serveRequest` * Java anonymous class method: `com.mycompany.Main$1.myMethod` * Java lambda method: `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod` * PHP function: `GuzzleHttp\Client::transfer` * Go function: `github.com/my/repo/pkg.foo.func5` * Elixir: `OpenTelemetry.Ctx.new` * Erlang: `opentelemetry_ctx:new` * Rust: `playground::my_module::my_cool_func` * C function: `fopen`
+                /// Values and format depends on each language runtime, thus it is impossible to provide an exhaustive list of examples.
+                /// The values are usually the same (or prefixes of) the ones found in native stack trace representation stored in
+                /// `code.stacktrace` without information on arguments.
+                ///
+                /// Examples:
+                ///
+                /// * Java method: `com.example.MyHttpService.serveRequest`
+                /// * Java anonymous class method: `com.mycompany.Main$1.myMethod`
+                /// * Java lambda method: `com.mycompany.Main$$Lambda/0x0000748ae4149c00.myMethod`
+                /// * PHP function: `GuzzleHttp\Client::transfer`
+                /// * Go function: `github.com/my/repo/pkg.foo.func5`
+                /// * Elixir: `OpenTelemetry.Ctx.new`
+                /// * Erlang: `opentelemetry_ctx:new`
+                /// * Rust: `playground::my_module::my_cool_func`
+                /// * C function: `fopen`
                 ///
                 /// - Examples:
                 ///     - `com.example.MyHttpService.serveRequest`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
@@ -42,16 +42,14 @@ extension SpanAttributes {
             /// `db.namespace`: The name of the database, fully qualified within the server address and port.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `customers`
+            ///     - `test.users`
             ///
             /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted.
             /// Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
             /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
-            ///
-            /// - Examples:
-            ///     - `customers`
-            ///     - `test.users`
             public var namespace: Self.Key<String> { .init(name: OTelAttribute.db.namespace) }
         }
 
@@ -79,8 +77,10 @@ extension SpanAttributes {
                 /// `db.collection.name`: The name of a collection (table, container) within the database.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Examples:
+                ///     - `public.users`
+                ///     - `customers`
                 ///
                 /// It is RECOMMENDED to capture the value as provided by the application
                 /// without attempting to do any case normalization.
@@ -91,10 +91,6 @@ extension SpanAttributes {
                 ///
                 /// For batch operations, if the individual operations are known to have the same
                 /// collection name then that collection name SHOULD be used.
-                ///
-                /// - Examples:
-                ///     - `public.users`
-                ///     - `customers`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.db.collection.name) }
             }
         }
@@ -123,8 +119,11 @@ extension SpanAttributes {
                 /// `db.operation.name`: The name of the operation or command being executed.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Examples:
+                ///     - `findAndModify`
+                ///     - `HMSET`
+                ///     - `SELECT`
                 ///
                 /// It is RECOMMENDED to capture the value as provided by the application
                 /// without attempting to do any case normalization.
@@ -140,11 +139,6 @@ extension SpanAttributes {
                 /// then that operation name SHOULD be used prepended by `BATCH `,
                 /// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
                 /// system specific term if more applicable.
-                ///
-                /// - Examples:
-                ///     - `findAndModify`
-                ///     - `HMSET`
-                ///     - `SELECT`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.db.operation.name) }
             }
 
@@ -172,15 +166,13 @@ extension SpanAttributes {
                     /// `db.operation.batch.size`: The number of queries included in a batch operation.
                     ///
                     /// - Stability: stable
-                    ///
                     /// - Type: int
-                    ///
-                    /// Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` SHOULD never be `1`.
-                    ///
                     /// - Examples:
                     ///     - `2`
                     ///     - `3`
                     ///     - `4`
+                    ///
+                    /// Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` SHOULD never be `1`.
                     public var size: Self.Key<Int> { .init(name: OTelAttribute.db.operation.batch.size) }
                 }
             }
@@ -210,8 +202,11 @@ extension SpanAttributes {
                 /// `db.query.summary`: Low cardinality summary of a database query.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Examples:
+                ///     - `SELECT wuser_table`
+                ///     - `INSERT shipping_details SELECT orders`
+                ///     - `get user by id`
                 ///
                 /// The query summary describes a class of database queries and is useful
                 /// as a grouping key, especially when analyzing telemetry for database
@@ -222,26 +217,19 @@ extension SpanAttributes {
                 /// that support query parsing SHOULD generate a summary following
                 /// [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query)
                 /// section.
-                ///
-                /// - Examples:
-                ///     - `SELECT wuser_table`
-                ///     - `INSERT shipping_details SELECT orders`
-                ///     - `get user by id`
                 public var summary: Self.Key<String> { .init(name: OTelAttribute.db.query.summary) }
 
                 /// `db.query.text`: The database query being executed.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Examples:
+                ///     - `SELECT * FROM wuser_table where username = ?`
+                ///     - `SET mykey ?`
                 ///
                 /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext).
                 /// For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
                 /// Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
-                ///
-                /// - Examples:
-                ///     - `SELECT * FROM wuser_table where username = ?`
-                ///     - `SET mykey ?`
                 public var text: Self.Key<String> { .init(name: OTelAttribute.db.query.text) }
             }
         }
@@ -270,17 +258,15 @@ extension SpanAttributes {
                 /// `db.response.status_code`: Database response status code.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
-                /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
-                /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
-                ///
                 /// - Examples:
                 ///     - `102`
                 ///     - `ORA-17002`
                 ///     - `08P01`
                 ///     - `404`
+                ///
+                /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
+                /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
                 public var statusCode: Self.Key<String> { .init(name: OTelAttribute.db.response.statusCode) }
             }
         }
@@ -309,16 +295,14 @@ extension SpanAttributes {
                 /// `db.stored_procedure.name`: The name of a stored procedure within the database.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Example: `GetCustomer`
                 ///
                 /// It is RECOMMENDED to capture the value as provided by the application
                 /// without attempting to do any case normalization.
                 ///
                 /// For batch operations, if the individual operations are known to have the same
                 /// stored procedure name then that stored procedure name SHOULD be used.
-                ///
-                /// - Example: `GetCustomer`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.db.storedProcedure.name) }
             }
         }
@@ -347,7 +331,6 @@ extension SpanAttributes {
                 /// `db.system.name`: The database management system (DBMS) product as identified by the client instrumentation.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: enum
                 ///     - `other_sql`: Some other SQL database. Fallback only.
                 ///     - `softwareag.adabas`: [Adabas (Adaptable Database System)](https://documentation.softwareag.com/?pf=adabas)

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
@@ -45,7 +45,9 @@ extension SpanAttributes {
             ///
             /// - Type: string
             ///
-            /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted. Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system. It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
+            /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted.
+            /// Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
+            /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
             ///
             /// - Examples:
             ///     - `customers`
@@ -80,7 +82,15 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  The collection name SHOULD NOT be extracted from `db.query.text`, when the database system supports query text with multiple collections in non-batch operations.  For batch operations, if the individual operations are known to have the same collection name then that collection name SHOULD be used.
+                /// It is RECOMMENDED to capture the value as provided by the application
+                /// without attempting to do any case normalization.
+                ///
+                /// The collection name SHOULD NOT be extracted from `db.query.text`,
+                /// when the database system supports query text with multiple collections
+                /// in non-batch operations.
+                ///
+                /// For batch operations, if the individual operations are known to have the same
+                /// collection name then that collection name SHOULD be used.
                 ///
                 /// - Examples:
                 ///     - `public.users`
@@ -116,7 +126,20 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  The operation name SHOULD NOT be extracted from `db.query.text`, when the database system supports query text with multiple operations in non-batch operations.  If spaces can occur in the operation name, multiple consecutive spaces SHOULD be normalized to a single space.  For batch operations, if the individual operations are known to have the same operation name then that operation name SHOULD be used prepended by `BATCH `, otherwise `db.operation.name` SHOULD be `BATCH` or some other database system specific term if more applicable.
+                /// It is RECOMMENDED to capture the value as provided by the application
+                /// without attempting to do any case normalization.
+                ///
+                /// The operation name SHOULD NOT be extracted from `db.query.text`,
+                /// when the database system supports query text with multiple operations
+                /// in non-batch operations.
+                ///
+                /// If spaces can occur in the operation name, multiple consecutive spaces
+                /// SHOULD be normalized to a single space.
+                ///
+                /// For batch operations, if the individual operations are known to have the same operation name
+                /// then that operation name SHOULD be used prepended by `BATCH `,
+                /// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
+                /// system specific term if more applicable.
                 ///
                 /// - Examples:
                 ///     - `findAndModify`
@@ -190,7 +213,15 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// The query summary describes a class of database queries and is useful as a grouping key, especially when analyzing telemetry for database calls involving complex queries.  Summary may be available to the instrumentation through instrumentation hooks or other means. If it is not available, instrumentations that support query parsing SHOULD generate a summary following [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query) section.
+                /// The query summary describes a class of database queries and is useful
+                /// as a grouping key, especially when analyzing telemetry for database
+                /// calls involving complex queries.
+                ///
+                /// Summary may be available to the instrumentation through
+                /// instrumentation hooks or other means. If it is not available, instrumentations
+                /// that support query parsing SHOULD generate a summary following
+                /// [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query)
+                /// section.
                 ///
                 /// - Examples:
                 ///     - `SELECT wuser_table`
@@ -204,7 +235,9 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext). For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable. Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
+                /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext).
+                /// For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
+                /// Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
                 ///
                 /// - Examples:
                 ///     - `SELECT * FROM wuser_table where username = ?`
@@ -240,7 +273,8 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes. Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
+                /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
+                /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
                 ///
                 /// - Examples:
                 ///     - `102`
@@ -278,7 +312,11 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.  For batch operations, if the individual operations are known to have the same stored procedure name then that stored procedure name SHOULD be used.
+                /// It is RECOMMENDED to capture the value as provided by the application
+                /// without attempting to do any case normalization.
+                ///
+                /// For batch operations, if the individual operations are known to have the same
+                /// stored procedure name then that stored procedure name SHOULD be used.
                 ///
                 /// - Example: `GetCustomer`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.db.storedProcedure.name) }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
@@ -46,7 +46,25 @@ extension SpanAttributes {
             /// - Type: enum
             ///     - `_OTHER`: A fallback error value to be used when the instrumentation doesn't define a custom value.
             ///
-            /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.  When `error.type` is set to a type (e.g., an exception type), its canonical class name identifying the type within the artifact SHOULD be used.  Instrumentations SHOULD document the list of errors they report.  The cardinality of `error.type` within one instrumentation library SHOULD be low. Telemetry consumers that aggregate data from multiple instrumentation libraries and applications should be prepared for `error.type` to have high cardinality at query time when no additional filters are applied.  If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.  If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes), it's RECOMMENDED to:  - Use a domain-specific attribute - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
+            /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
+            ///
+            /// When `error.type` is set to a type (e.g., an exception type), its
+            /// canonical class name identifying the type within the artifact SHOULD be used.
+            ///
+            /// Instrumentations SHOULD document the list of errors they report.
+            ///
+            /// The cardinality of `error.type` within one instrumentation library SHOULD be low.
+            /// Telemetry consumers that aggregate data from multiple instrumentation libraries and applications
+            /// should be prepared for `error.type` to have high cardinality at query time when no
+            /// additional filters are applied.
+            ///
+            /// If the operation has completed successfully, instrumentations SHOULD NOT set `error.type`.
+            ///
+            /// If a specific domain defines its own set of error identifiers (such as HTTP or gRPC status codes),
+            /// it's RECOMMENDED to:
+            ///
+            /// - Use a domain-specific attribute
+            /// - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
             ///
             /// - Examples:
             ///     - `timeout`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
@@ -42,9 +42,13 @@ extension SpanAttributes {
             /// `error.type`: Describes a class of error the operation ended with.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `_OTHER`: A fallback error value to be used when the instrumentation doesn't define a custom value.
+            /// - Examples:
+            ///     - `timeout`
+            ///     - `java.net.UnknownHostException`
+            ///     - `server_certificate_invalid`
+            ///     - `500`
             ///
             /// The `error.type` SHOULD be predictable, and SHOULD have low cardinality.
             ///
@@ -65,12 +69,6 @@ extension SpanAttributes {
             ///
             /// - Use a domain-specific attribute
             /// - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
-            ///
-            /// - Examples:
-            ///     - `timeout`
-            ///     - `java.net.UnknownHostException`
-            ///     - `server_certificate_invalid`
-            ///     - `500`
             public var `type`: Self.Key<TypeEnum> { .init(name: OTelAttribute.error.`type`) }
 
             public struct TypeEnum: SpanAttributeConvertible, Sendable {

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
@@ -42,7 +42,6 @@ extension SpanAttributes {
             /// `exception.escaped`: Indicates that the exception is escaping the scope of the span.
             ///
             /// - Stability: stable
-            ///
             /// - Type: boolean
             @available(
                 *,
@@ -55,9 +54,7 @@ extension SpanAttributes {
             /// `exception.message`: The exception message.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `Division by zero`
             ///     - `Can't convert 'int' object to str implicitly`
@@ -66,9 +63,7 @@ extension SpanAttributes {
             /// `exception.stacktrace`: A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
             /// `
             public var stacktrace: Self.Key<String> { .init(name: OTelAttribute.exception.stacktrace) }
@@ -76,9 +71,7 @@ extension SpanAttributes {
             /// `exception.type`: The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `java.net.ConnectException`
             ///     - `OSError`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
@@ -45,7 +45,8 @@ extension SpanAttributes {
             ///
             /// - Type: string
             ///
-            /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it. SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
+            /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+            /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
             ///
             /// - Examples:
             ///     - `/users/:userID?`
@@ -77,7 +78,22 @@ extension SpanAttributes {
             ///
             /// - Type: templateStringArray
             ///
-            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information.  The `User-Agent` header is already captured in the `user_agent.original` attribute. Users MAY explicitly configure instrumentations to capture them even though it is not recommended.  The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.  Examples:  - A header `Content-Type: application/json` SHOULD be recorded as the `http.request.header.content-type`   attribute with value `["application/json"]`. - A header `X-Forwarded-For: 1.2.3.4, 1.2.3.5` SHOULD be recorded as the `http.request.header.x-forwarded-for`   attribute with value `["1.2.3.4", "1.2.3.5"]` or `["1.2.3.4, 1.2.3.5"]` depending on the HTTP library.
+            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
+            /// Including all request headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+            ///
+            /// The `User-Agent` header is already captured in the `user_agent.original` attribute.
+            /// Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
+            ///
+            /// The attribute value MUST consist of either multiple header values as an array of strings
+            /// or a single-item array containing a possibly comma-concatenated string, depending on the way
+            /// the HTTP library provides access to headers.
+            ///
+            /// Examples:
+            ///
+            /// - A header `Content-Type: application/json` SHOULD be recorded as the `http.request.header.content-type`
+            ///   attribute with value `["application/json"]`.
+            /// - A header `X-Forwarded-For: 1.2.3.4, 1.2.3.5` SHOULD be recorded as the `http.request.header.x-forwarded-for`
+            ///   attribute with value `["1.2.3.4", "1.2.3.5"]` or `["1.2.3.4, 1.2.3.5"]` depending on the HTTP library.
             public var header: HeaderAttributes {
                 get {
                     .init(attributes: self.attributes)
@@ -135,7 +151,20 @@ extension SpanAttributes {
                 ///     - `TRACE`: TRACE method.
                 ///     - `_OTHER`: Any HTTP method that the instrumentation has no prior knowledge of.
                 ///
-                /// HTTP request method value SHOULD be "known" to the instrumentation. By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods) and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).  If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.  If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).  HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly. Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent. Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
+                /// HTTP request method value SHOULD be "known" to the instrumentation.
+                /// By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
+                /// and the PATCH method defined in [RFC5789](https://www.rfc-editor.org/rfc/rfc5789.html).
+                ///
+                /// If the HTTP request method is not known to instrumentation, it MUST set the `http.request.method` attribute to `_OTHER`.
+                ///
+                /// If the HTTP instrumentation could end up converting valid HTTP request methods to `_OTHER`, then it MUST provide a way to override
+                /// the list of known HTTP methods. If this override is done via environment variable, then the environment variable MUST be named
+                /// OTEL_INSTRUMENTATION_HTTP_KNOWN_METHODS and support a comma-separated list of case-sensitive known HTTP methods
+                /// (this list MUST be a full override of the default known method, it is not a list of known methods in addition to the defaults).
+                ///
+                /// HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
+                /// Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
+                /// Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
                 ///
                 /// - Examples:
                 ///     - `GET`
@@ -219,7 +248,21 @@ extension SpanAttributes {
             ///
             /// - Type: templateStringArray
             ///
-            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured. Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.  Users MAY explicitly configure instrumentations to capture them even though it is not recommended.  The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.  Examples:  - A header `Content-Type: application/json` header SHOULD be recorded as the `http.request.response.content-type`   attribute with value `["application/json"]`. - A header `My-custom-header: abc, def` header SHOULD be recorded as the `http.response.header.my-custom-header`   attribute with value `["abc", "def"]` or `["abc, def"]` depending on the HTTP library.
+            /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
+            /// Including all response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+            ///
+            /// Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
+            ///
+            /// The attribute value MUST consist of either multiple header values as an array of strings
+            /// or a single-item array containing a possibly comma-concatenated string, depending on the way
+            /// the HTTP library provides access to headers.
+            ///
+            /// Examples:
+            ///
+            /// - A header `Content-Type: application/json` header SHOULD be recorded as the `http.request.response.content-type`
+            ///   attribute with value `["application/json"]`.
+            /// - A header `My-custom-header: abc, def` header SHOULD be recorded as the `http.response.header.my-custom-header`
+            ///   attribute with value `["abc", "def"]` or `["abc, def"]` depending on the HTTP library.
             public var header: HeaderAttributes {
                 get {
                     .init(attributes: self.attributes)

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
@@ -42,15 +42,13 @@ extension SpanAttributes {
             /// `http.route`: The matched route, that is, the path template in the format used by the respective server framework.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-            /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-            ///
             /// - Examples:
             ///     - `/users/:userID?`
             ///     - `{controller}/{action}/{id?}`
+            ///
+            /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+            /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
             public var route: Self.Key<String> { .init(name: OTelAttribute.http.route) }
         }
 
@@ -75,7 +73,6 @@ extension SpanAttributes {
             /// `http.request.header`: HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
             ///
             /// - Stability: stable
-            ///
             /// - Type: templateStringArray
             ///
             /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
@@ -138,7 +135,6 @@ extension SpanAttributes {
                 /// `http.request.method`: HTTP request method.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: enum
                 ///     - `CONNECT`: CONNECT method.
                 ///     - `DELETE`: DELETE method.
@@ -150,6 +146,10 @@ extension SpanAttributes {
                 ///     - `PUT`: PUT method.
                 ///     - `TRACE`: TRACE method.
                 ///     - `_OTHER`: Any HTTP method that the instrumentation has no prior knowledge of.
+                /// - Examples:
+                ///     - `GET`
+                ///     - `POST`
+                ///     - `HEAD`
                 ///
                 /// HTTP request method value SHOULD be "known" to the instrumentation.
                 /// By default, this convention defines "known" methods as the ones listed in [RFC9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-methods)
@@ -165,11 +165,6 @@ extension SpanAttributes {
                 /// HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
                 /// Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
                 /// Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-                ///
-                /// - Examples:
-                ///     - `GET`
-                ///     - `POST`
-                ///     - `HEAD`
                 public var method: Self.Key<MethodEnum> { .init(name: OTelAttribute.http.request.method) }
 
                 public struct MethodEnum: SpanAttributeConvertible, Sendable {
@@ -202,9 +197,7 @@ extension SpanAttributes {
                 /// `http.request.method_original`: Original HTTP method sent by the client in the request line.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Examples:
                 ///     - `GeT`
                 ///     - `ACL`
@@ -214,12 +207,10 @@ extension SpanAttributes {
                 /// `http.request.resend_count`: The ordinal number of request resending attempt (for any reason, including redirects).
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
+                /// - Example: `3`
                 ///
                 /// The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-                ///
-                /// - Example: `3`
                 public var resendCount: Self.Key<Int> { .init(name: OTelAttribute.http.request.resendCount) }
             }
         }
@@ -245,7 +236,6 @@ extension SpanAttributes {
             /// `http.response.header`: HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase), the value being the header values.
             ///
             /// - Stability: stable
-            ///
             /// - Type: templateStringArray
             ///
             /// Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
@@ -307,9 +297,7 @@ extension SpanAttributes {
                 /// `http.response.status_code`: [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
                 /// - Example: `200`
                 public var statusCode: Self.Key<Int> { .init(name: OTelAttribute.http.response.statusCode) }
             }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
@@ -42,23 +42,21 @@ extension SpanAttributes {
             /// `network.transport`: [OSI transport layer](https://wikipedia.org/wiki/Transport_layer) or [inter-process communication method](https://wikipedia.org/wiki/Inter-process_communication).
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `tcp`: TCP
             ///     - `udp`: UDP
             ///     - `pipe`: Named or anonymous pipe.
             ///     - `unix`: Unix domain socket
             ///     - `quic`: QUIC
+            /// - Examples:
+            ///     - `tcp`
+            ///     - `udp`
             ///
             /// The value SHOULD be normalized to lowercase.
             ///
             /// Consider always setting the transport when setting a port number, since
             /// a port number is ambiguous without knowing the transport. For example
             /// different processes could be listening on TCP port 12345 and UDP port 12345.
-            ///
-            /// - Examples:
-            ///     - `tcp`
-            ///     - `udp`
             public var transport: Self.Key<TransportEnum> { .init(name: OTelAttribute.network.transport) }
 
             public struct TransportEnum: SpanAttributeConvertible, Sendable {
@@ -81,16 +79,14 @@ extension SpanAttributes {
             /// `network.type`: [OSI network layer](https://wikipedia.org/wiki/Network_layer) or non-OSI equivalent.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `ipv4`: IPv4
             ///     - `ipv6`: IPv6
-            ///
-            /// The value SHOULD be normalized to lowercase.
-            ///
             /// - Examples:
             ///     - `ipv4`
             ///     - `ipv6`
+            ///
+            /// The value SHOULD be normalized to lowercase.
             public var `type`: Self.Key<TypeEnum> { .init(name: OTelAttribute.network.`type`) }
 
             public struct TypeEnum: SpanAttributeConvertible, Sendable {
@@ -129,9 +125,7 @@ extension SpanAttributes {
                 /// `network.local.address`: Local address of the network connection - IP address or Unix domain socket name.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Examples:
                 ///     - `10.1.2.80`
                 ///     - `/tmp/my.sock`
@@ -140,9 +134,7 @@ extension SpanAttributes {
                 /// `network.local.port`: Local port number of the network connection.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
                 /// - Example: `65123`
                 public var port: Self.Key<Int> { .init(name: OTelAttribute.network.local.port) }
             }
@@ -172,9 +164,7 @@ extension SpanAttributes {
                 /// `network.peer.address`: Peer address of the network connection - IP address or Unix domain socket name.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Examples:
                 ///     - `10.1.2.80`
                 ///     - `/tmp/my.sock`
@@ -183,9 +173,7 @@ extension SpanAttributes {
                 /// `network.peer.port`: Peer port number of the network connection.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: int
-                ///
                 /// - Example: `65123`
                 public var port: Self.Key<Int> { .init(name: OTelAttribute.network.peer.port) }
             }
@@ -215,28 +203,24 @@ extension SpanAttributes {
                 /// `network.protocol.name`: [OSI application layer](https://wikipedia.org/wiki/Application_layer) or non-OSI equivalent.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
-                /// The value SHOULD be normalized to lowercase.
-                ///
                 /// - Examples:
                 ///     - `amqp`
                 ///     - `http`
                 ///     - `mqtt`
+                ///
+                /// The value SHOULD be normalized to lowercase.
                 public var name: Self.Key<String> { .init(name: OTelAttribute.network.`protocol`.name) }
 
                 /// `network.protocol.version`: The actual version of the protocol used for network communication.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
-                /// If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
-                ///
                 /// - Examples:
                 ///     - `1.1`
                 ///     - `2`
+                ///
+                /// If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
                 public var version: Self.Key<String> { .init(name: OTelAttribute.network.`protocol`.version) }
             }
         }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
@@ -50,7 +50,11 @@ extension SpanAttributes {
             ///     - `unix`: Unix domain socket
             ///     - `quic`: QUIC
             ///
-            /// The value SHOULD be normalized to lowercase.  Consider always setting the transport when setting a port number, since a port number is ambiguous without knowing the transport. For example different processes could be listening on TCP port 12345 and UDP port 12345.
+            /// The value SHOULD be normalized to lowercase.
+            ///
+            /// Consider always setting the transport when setting a port number, since
+            /// a port number is ambiguous without knowing the transport. For example
+            /// different processes could be listening on TCP port 12345 and UDP port 12345.
             ///
             /// - Examples:
             ///     - `tcp`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+otel.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+otel.swift
@@ -42,7 +42,6 @@ extension SpanAttributes {
             /// `otel.status_code`: Name of the code, either "OK" or "ERROR". MUST NOT be set if the status code is UNSET.
             ///
             /// - Stability: stable
-            ///
             /// - Type: enum
             ///     - `OK`: The operation has been validated by an Application developer or Operator to have completed successfully.
             ///     - `ERROR`: The operation contains an error.
@@ -62,9 +61,7 @@ extension SpanAttributes {
             /// `otel.status_description`: Description of the Status if it has a value, otherwise not set.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `resource not found`
             public var statusDescription: Self.Key<String> { .init(name: OTelAttribute.otel.statusDescription) }
         }
@@ -93,18 +90,14 @@ extension SpanAttributes {
                 /// `otel.scope.name`: The name of the instrumentation scope - (`InstrumentationScope.Name` in OTLP).
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Example: `io.opentelemetry.contrib.mongodb`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.otel.scope.name) }
 
                 /// `otel.scope.version`: The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Example: `1.0.0`
                 public var version: Self.Key<String> { .init(name: OTelAttribute.otel.scope.version) }
             }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+server.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+server.swift
@@ -42,29 +42,25 @@ extension SpanAttributes {
             /// `server.address`: Server domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
-            /// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
-            ///
             /// - Examples:
             ///     - `example.com`
             ///     - `10.1.2.80`
             ///     - `/tmp/my.sock`
+            ///
+            /// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
             public var address: Self.Key<String> { .init(name: OTelAttribute.server.address) }
 
             /// `server.port`: Server port number.
             ///
             /// - Stability: stable
-            ///
             /// - Type: int
-            ///
-            /// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-            ///
             /// - Examples:
             ///     - `80`
             ///     - `8080`
             ///     - `443`
+            ///
+            /// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
             public var port: Self.Key<Int> { .init(name: OTelAttribute.server.port) }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+service.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+service.swift
@@ -42,20 +42,16 @@ extension SpanAttributes {
             /// `service.name`: Logical name of the service.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Example: `shoppingcart`
             ///
             /// MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-            ///
-            /// - Example: `shoppingcart`
             public var name: Self.Key<String> { .init(name: OTelAttribute.service.name) }
 
             /// `service.version`: The version string of the service API or implementation. The format is not defined by these conventions.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `2.0.0`
             ///     - `a01dbef8a`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
@@ -64,7 +64,6 @@ extension SpanAttributes {
                 /// `telemetry.sdk.language`: The language of the telemetry SDK.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: enum
                 ///     - `cpp`
                 ///     - `dotnet`
@@ -114,8 +113,8 @@ extension SpanAttributes {
                 /// `telemetry.sdk.name`: The name of the telemetry SDK as defined above.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
+                /// - Example: `opentelemetry`
                 ///
                 /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
                 /// If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
@@ -123,16 +122,12 @@ extension SpanAttributes {
                 /// or another suitable identifier depending on the language.
                 /// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
                 /// All custom identifiers SHOULD be stable across different versions of an implementation.
-                ///
-                /// - Example: `opentelemetry`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.telemetry.sdk.name) }
 
                 /// `telemetry.sdk.version`: The version string of the telemetry SDK.
                 ///
                 /// - Stability: stable
-                ///
                 /// - Type: string
-                ///
                 /// - Example: `1.2.3`
                 public var version: Self.Key<String> { .init(name: OTelAttribute.telemetry.sdk.version) }
             }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
@@ -117,7 +117,12 @@ extension SpanAttributes {
                 ///
                 /// - Type: string
                 ///
-                /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`. If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point or another suitable identifier depending on the language. The identifier `opentelemetry` is reserved and MUST NOT be used in this case. All custom identifiers SHOULD be stable across different versions of an implementation.
+                /// The OpenTelemetry SDK MUST set the `telemetry.sdk.name` attribute to `opentelemetry`.
+                /// If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the
+                /// `telemetry.sdk.name` attribute to the fully-qualified class or module name of this SDK's main entry point
+                /// or another suitable identifier depending on the language.
+                /// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
+                /// All custom identifiers SHOULD be stable across different versions of an implementation.
                 ///
                 /// - Example: `opentelemetry`
                 public var name: Self.Key<String> { .init(name: OTelAttribute.telemetry.sdk.name) }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
@@ -54,7 +54,29 @@ extension SpanAttributes {
             ///
             /// - Type: string
             ///
-            /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.  `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.  `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed).  Sensitive content provided in `url.full` SHOULD be scrubbed when instrumentations can identify it.  ![Development](https://img.shields.io/badge/-development-blue) Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:  * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token) * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)  This list is subject to change over time.  When a query string value is redacted, the query string key SHOULD still be preserved, e.g. `https://www.example.com/path?color=blue&sig=REDACTED`.
+            /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
+            /// is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
+            ///
+            /// `url.full` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
+            /// In such case username and password SHOULD be redacted and attribute's value SHOULD be `https://REDACTED:REDACTED@www.example.com/`.
+            ///
+            /// `url.full` SHOULD capture the absolute URL when it is available (or can be reconstructed).
+            ///
+            /// Sensitive content provided in `url.full` SHOULD be scrubbed when instrumentations can identify it.
+            ///
+            /// ![Development](https://img.shields.io/badge/-development-blue)
+            /// Query string values for the following keys SHOULD be redacted by default and replaced by the
+            /// value `REDACTED`:
+            ///
+            /// * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+            /// * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+            /// * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
+            /// * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+            ///
+            /// This list is subject to change over time.
+            ///
+            /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
+            /// `https://www.example.com/path?color=blue&sig=REDACTED`.
             ///
             /// - Examples:
             ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
@@ -78,7 +100,20 @@ extension SpanAttributes {
             ///
             /// - Type: string
             ///
-            /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.  ![Development](https://img.shields.io/badge/-development-blue) Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:  * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth) * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token) * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)  This list is subject to change over time.  When a query string value is redacted, the query string key SHOULD still be preserved, e.g. `q=OpenTelemetry&sig=REDACTED`.
+            /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.
+            ///
+            /// ![Development](https://img.shields.io/badge/-development-blue)
+            /// Query string values for the following keys SHOULD be redacted by default and replaced by the value `REDACTED`:
+            ///
+            /// * [`AWSAccessKeyId`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+            /// * [`Signature`](https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html#RESTAuthenticationQueryStringAuth)
+            /// * [`sig`](https://learn.microsoft.com/azure/storage/common/storage-sas-overview#sas-token)
+            /// * [`X-Goog-Signature`](https://cloud.google.com/storage/docs/access-control/signed-urls)
+            ///
+            /// This list is subject to change over time.
+            ///
+            /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
+            /// `q=OpenTelemetry&sig=REDACTED`.
             ///
             /// - Example: `q=OpenTelemetry`
             public var query: Self.Key<String> { .init(name: OTelAttribute.url.query) }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
@@ -42,17 +42,17 @@ extension SpanAttributes {
             /// `url.fragment`: The [URI fragment](https://www.rfc-editor.org/rfc/rfc3986#section-3.5) component
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Example: `SemConv`
             public var fragment: Self.Key<String> { .init(name: OTelAttribute.url.fragment) }
 
             /// `url.full`: Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Examples:
+            ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
+            ///     - `//localhost`
             ///
             /// For network calls, URL usually has `scheme://host[:port][path][?query][#fragment]` format, where the fragment
             /// is not transmitted over HTTP, but if it is known, it SHOULD be included nevertheless.
@@ -77,28 +77,22 @@ extension SpanAttributes {
             ///
             /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
             /// `https://www.example.com/path?color=blue&sig=REDACTED`.
-            ///
-            /// - Examples:
-            ///     - `https://www.foo.bar/search?q=OpenTelemetry#SemConv`
-            ///     - `//localhost`
             public var full: Self.Key<String> { .init(name: OTelAttribute.url.full) }
 
             /// `url.path`: The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Example: `/search`
             ///
             /// Sensitive content provided in `url.path` SHOULD be scrubbed when instrumentations can identify it.
-            ///
-            /// - Example: `/search`
             public var path: Self.Key<String> { .init(name: OTelAttribute.url.path) }
 
             /// `url.query`: The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
+            /// - Example: `q=OpenTelemetry`
             ///
             /// Sensitive content provided in `url.query` SHOULD be scrubbed when instrumentations can identify it.
             ///
@@ -114,16 +108,12 @@ extension SpanAttributes {
             ///
             /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
             /// `q=OpenTelemetry&sig=REDACTED`.
-            ///
-            /// - Example: `q=OpenTelemetry`
             public var query: Self.Key<String> { .init(name: OTelAttribute.url.query) }
 
             /// `url.scheme`: The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `https`
             ///     - `ftp`

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+userAgent.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+userAgent.swift
@@ -42,9 +42,7 @@ extension SpanAttributes {
             /// `user_agent.original`: Value of the [HTTP User-Agent](https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent) header sent by the client.
             ///
             /// - Stability: stable
-            ///
             /// - Type: string
-            ///
             /// - Examples:
             ///     - `CERN-LineMode/2.15 libwww/2.17b3`
             ///     - `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1`


### PR DESCRIPTION
This makes the following changes:

1. It ensures that newlines in the attributes `note` field are preserved, resolving https://github.com/swift-otel/swift-otel-semantic-conventions/issues/16
2. It improves consistency of newline handling in attribute and enum `brief` fields in the generator. This has no impact on the current generated code.
3. It moves `example` documentation above the attribute `note` to create a more structured list of attribute metadata (i.e. stability, type, and examples). It also removes extra newlines so that the metadata is a proper markdown list.