### PR TITLE
Improves Swift `available` attribute generation based on OTel deprecation metadata

### DIFF
--- a/Generator/Package.swift
+++ b/Generator/Package.swift
@@ -21,7 +21,14 @@ let package = Package(
                 .product(name: "Yams", package: "Yams"),
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             ]
-        )
+        ),
+        .testTarget(
+            name: "GeneratorTests",
+            dependencies: [
+                "Generator",
+                .product(name: "Yams", package: "Yams"),
+            ]
+        ),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/Generator/Sources/FileRenderer.swift
+++ b/Generator/Sources/FileRenderer.swift
@@ -54,6 +54,36 @@ func renderDocs(_ attribute: Attribute) -> String {
     return result.prefixLines(with: "/// ")
 }
 
+/// Render the `@available` Swift attribute for a deprecated OTel attribute
+///
+/// - Parameters:
+///   - deprecated: The `Deprecated` enum that describes the deprecation
+///   - extendedTypeName: The name of the type being extended with this attribute (i.e. OTelAttribute, or SpanAttributes). Used in the `renamed` argument, if applicable.
+/// - Returns: A string representing the `@available` attribute for Swift
+func renderDeprecatedAttribute(_ deprecated: Deprecated, extendedTypeName: String) -> String {
+    var result = "@available(*, deprecated"
+    switch deprecated {
+    case let .renamed(renamed_to, note):
+        let renamedTo = renamed_to
+        result.append(", renamed: \"\(extendedTypeName).\(renamedTo)\"")
+        if let note = note?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            result.append(", message: \"\(note)\"")
+        }
+    case let .obsoleted(note):
+        var message = "Obsoleted"
+        if let note = note?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            message.append(": \(note)")
+        }
+        result.append(", message: \"\(message)\"")
+    case let .uncategorized(note):
+        if let note = note?.trimmingCharacters(in: .whitespacesAndNewlines) {
+            result.append(", message: \"\(note)\"")
+        }
+    }
+    result.append(")")
+    return result
+}
+
 extension String {
     func prefixLines(with prefix: String) -> String {
         self.split(separator: "\n", omittingEmptySubsequences: false)

--- a/Generator/Sources/FileRenderers/OTelAttributeRenderer.swift
+++ b/Generator/Sources/FileRenderers/OTelAttributeRenderer.swift
@@ -51,8 +51,8 @@ struct OTelAttributeRenderer: FileRenderer {
 
     private func renderAttribute(_ attribute: Attribute, _ namespace: Namespace, indent: Int) throws -> String {
         var result = renderDocs(attribute)
-        if let deprecatedMessage = attribute.deprecated?.note?.trimmingCharacters(in: .whitespacesAndNewlines) {
-            result.append("\n@available(*, deprecated, message: \"\(deprecatedMessage)\")")
+        if let deprecated = attribute.deprecated {
+            result.append("\n" + renderDeprecatedAttribute(deprecated, extendedTypeName: "OTelAttribute"))
         }
         try result.append(
             "\npublic static let \(swiftOTelAttributePropertyName(attribute, namespace)) = \"\(attribute.id)\""

--- a/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
+++ b/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
@@ -110,8 +110,8 @@ struct SpanAttributeRenderer: FileRenderer {
         propertyName = nameGenerator.swiftMemberName(for: propertyName)
 
         var result = renderDocs(attribute)
-        if let deprecatedMessage = attribute.deprecated?.note?.trimmingCharacters(in: .whitespacesAndNewlines) {
-            result.append("\n@available(*, deprecated, message: \"\(deprecatedMessage)\")")
+        if let deprecated = attribute.deprecated {
+            result.append("\n" + renderDeprecatedAttribute(deprecated, extendedTypeName: "SpanAttributes"))
         }
 
         let swiftType: String

--- a/Generator/Tests/DecodingTests.swift
+++ b/Generator/Tests/DecodingTests.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+import Yams
+
+@testable import Generator
+
+struct DecodingTests {
+    @Test func decodeDeprecated() throws {
+        let actual = try YAMLDecoder().decode(
+            [Deprecated].self,
+            from: """
+                - 'Replaced by `jvm.buffer.memory.used`.'
+                - reason: obsoleted
+                - reason: renamed
+                  renamed_to: foo.unique_id
+                - reason: uncategorized
+                  note: This field is deprecated for some complex reasons.
+                - reason: renamed
+                  renamed_to: foo.unique_id
+                  note: Replaced by a new attribute `foo.unique_id`.
+                """
+        )
+        #expect(
+            actual == [
+                .uncategorized(note: "Replaced by `jvm.buffer.memory.used`."),
+                .obsoleted(note: nil),
+                .renamed(renamed_to: "foo.unique_id", note: nil),
+                .uncategorized(note: "This field is deprecated for some complex reasons."),
+                .renamed(renamed_to: "foo.unique_id", note: "Replaced by a new attribute `foo.unique_id`."),
+            ]
+        )
+    }
+}

--- a/Generator/Tests/RenderDeprecatedAttributeTests.swift
+++ b/Generator/Tests/RenderDeprecatedAttributeTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Testing
+
+@testable import Generator
+
+struct RenderDeprecatedAttributeTests {
+    @Test func testRenamed() {
+        let actual = renderDeprecatedAttribute(
+            .renamed(renamed_to: "bar.baz", note: "Replaced by a new attribute `bar.baz`"),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated, renamed: \"Foo.bar.baz\", message: \"Replaced by a new attribute `bar.baz`\")"
+        )
+    }
+
+    @Test func testRenamedNoNote() {
+        let actual = renderDeprecatedAttribute(
+            .renamed(renamed_to: "bar.baz", note: nil),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated, renamed: \"Foo.bar.baz\")"
+        )
+    }
+
+    @Test func testObsoleted() {
+        let actual = renderDeprecatedAttribute(
+            .obsoleted(note: "Don't use `bar.baz`"),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated, message: \"Obsoleted: Don't use `bar.baz`\")"
+        )
+    }
+
+    @Test func testObsoletedNoNote() {
+        let actual = renderDeprecatedAttribute(
+            .obsoleted(note: nil),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated, message: \"Obsoleted\")"
+        )
+    }
+
+    @Test func testUncategorized() {
+        let actual = renderDeprecatedAttribute(
+            .uncategorized(note: "No additional information about `bar.baz`"),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated, message: \"No additional information about `bar.baz`\")"
+        )
+    }
+
+    @Test func testUncategorizedNoNote() {
+        let actual = renderDeprecatedAttribute(
+            .uncategorized(note: nil),
+            extendedTypeName: "Foo"
+        )
+        #expect(
+            actual
+                == "@available(*, deprecated)"
+        )
+    }
+}

--- a/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+exception.swift
+++ b/Sources/OTelSemanticConventions/Generated/AttributeNames/OTelAttribute+exception.swift
@@ -24,7 +24,7 @@ extension OTelAttribute {
             *,
             deprecated,
             message:
-                "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
+                "Obsoleted: It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
         )
         public static let escaped = "exception.escaped"
 

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
@@ -47,7 +47,7 @@ extension SpanAttributes {
                 *,
                 deprecated,
                 message:
-                    "It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
+                    "Obsoleted: It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
             )
             public var escaped: Self.Key<Bool> { .init(name: OTelAttribute.exception.escaped) }
 


### PR DESCRIPTION
This decodes the different OTel deprecation type options, and renders different Swift `@available` attributes based on that type. Specifically, `renamed` attributes get a `renamed` argument in the Swift attribute, and `obsoleted` get a prefix to their `message`. Non-labeled OTel deprecations are interpreted as `uncategorized`, which are translated to an ordinary Swift deprecation without a `renamed` section or `message` prefix.

It introduces tests to the Generator package, covering these particular decoding and generation paths.

This resolves https://github.com/swift-otel/swift-otel-semantic-conventions/issues/15