### PR TITLE
Add Makefile to generate Xcode workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 .DS_Store
 /Package.resolved
+swift-otel-semantic-conventions.xcworkspace/

--- a/.licenseignore
+++ b/.licenseignore
@@ -9,6 +9,7 @@
 Package.swift
 Package.resolved
 CODEOWNERS
+Makefile
 **/.gitignore
 **/Package.swift
 **/Package.resolved

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Xcode workspace with main package and generator
+# -----------------------------------------------------------------------------
+WORKSPACE = swift-otel-semantic-conventions.xcworkspace
+WORKSPACE_CONTENTS = $(WORKSPACE)/contents.xcworkspacedata
+
+workspace: $(WORKSPACE_CONTENTS)  # Generate and open Xcode workspace including examples.
+	open $(WORKSPACE)
+
+define contents_xcworkspacedata
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace version="1.0">
+	<FileRef location="group:."></FileRef>
+	<FileRef location="group:Generator"></FileRef>
+</Workspace>
+endef
+export contents_xcworkspacedata
+
+$(WORKSPACE_CONTENTS): Makefile
+	rm -rf $(WORKSPACE)
+	mkdir -p $(dir $@)
+	echo "$$contents_xcworkspacedata" > $@
+
+.DELETE_ON_ERROR:


### PR DESCRIPTION
This PR adds a `Makefile` for generating an Xcode workspace that combines the main package and the Generator package, making development on the package a bit more comfortable when using Xcode. Kudos to @simonjbeaumont for creating a similar [`Makefile`](https://github.com/swift-otel/swift-otel/blob/main/Makefile) for Swift OTel which served as a blueprint for this one.