### PR TITLE
Generate the DocC documentation catalog

### DIFF
--- a/Generator/Sources/FileRenderer.swift
+++ b/Generator/Sources/FileRenderer.swift
@@ -25,8 +25,23 @@ protocol FileRenderer {
 }
 
 /// Contains top-level information about the rendering execution
-struct Context {
+final class Context {
     let rootNamespace: Namespace
+
+    /// The symbols generated for each attribute, separated by the human-readable renderer name.
+    ///
+    /// Example:
+    /// ```swift
+    /// ["code.column.number": ["String Constants": "OTelAttribute/code/column/number"]]
+    /// ```
+    ///
+    /// `FileRenderer`s are expected to populate this dictionary while generating.
+    var doccSymbolReferences: [String: [String: String]]
+
+    init(rootNamespace: Namespace, doccSymbolReferences: [String: [String: String]]) {
+        self.rootNamespace = rootNamespace
+        self.doccSymbolReferences = doccSymbolReferences
+    }
 }
 
 extension FileRenderer {

--- a/Generator/Sources/FileRenderers/OTelAttributeRenderer.swift
+++ b/Generator/Sources/FileRenderers/OTelAttributeRenderer.swift
@@ -77,7 +77,9 @@ struct OTelAttributeRenderer: FileRenderer {
         }
 
         let attributeMemberName = try attributeMemberName(attribute.id, namespace)
-        let doccSymbolReference = (doccSymbolPrefix + [attributeMemberName]).joined(separator: "/")
+        let doccSymbolReference = (doccSymbolPrefix + [attributeMemberName])
+            .joined(separator: "/")
+            .replacingOccurrences(of: "`", with: "")
         context.doccSymbolReferences[attribute.id, default: [:]]["String Constants"] = doccSymbolReference
 
         result.append(

--- a/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
+++ b/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
@@ -151,12 +151,12 @@ struct SpanAttributeRenderer: FileRenderer {
                 throw SpanAttributeRendererError.invalidStandardAttributeType(attribute.type)
             }
             result.append(
-                "\npublic var \(propertyName): Self.Key<\(swiftType)> { .init(name: \(otelAttributePath)) }"
+                "\npublic var \(propertyName): SpanAttributeKey<\(swiftType)> { .init(name: \(otelAttributePath)) }"
             )
         } else if let type = attribute.type as? Attribute.EnumType {
             let enumTypeName = "\(nameGenerator.swiftTypeName(for: "\(attributeName)Enum"))"
             result.append(
-                "\npublic var \(propertyName): Self.Key<\(enumTypeName)> { .init(name: \(otelAttributePath)) }"
+                "\npublic var \(propertyName): SpanAttributeKey<\(enumTypeName)> { .init(name: \(otelAttributePath)) }"
             )
 
             // Enum types are not represented as Swift enums to avoid breaking changes when new enum values are added.

--- a/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
+++ b/Generator/Sources/FileRenderers/SpanAttributeRenderer.swift
@@ -158,7 +158,9 @@ struct SpanAttributeRenderer: FileRenderer {
             throw GeneratorError.attributeNameNotFound(attribute.id)
         }
         let propertyName = try attributeMemberName(attribute.id, namespace)
-        let symbolReference = (doccSymbolPrefix + [propertyName]).joined(separator: "/")
+        let symbolReference = (doccSymbolPrefix + [propertyName])
+            .joined(separator: "/")
+            .replacingOccurrences(of: "`", with: "")
         context.doccSymbolReferences[attribute.id, default: [:]]["Span Attributes"] = symbolReference
 
         var result = renderDocs(attribute)
@@ -234,7 +236,9 @@ struct SpanAttributeRenderer: FileRenderer {
             throw GeneratorError.attributeNameNotFound(attribute.id)
         }
         let swiftName = try attributeMemberName(attribute.id, namespace)
-        let symbolReference = (doccSymbolPrefix + [swiftName]).joined(separator: "/")
+        let symbolReference = (doccSymbolPrefix + [swiftName])
+            .joined(separator: "/")
+            .replacingOccurrences(of: "`", with: "")
         context.doccSymbolReferences[attribute.id, default: [:]]["Span Attributes"] = symbolReference
         let structName = nameGenerator.swiftTypeName(for: "\(attributeName)Attributes")
 

--- a/Generator/Sources/Generator.swift
+++ b/Generator/Sources/Generator.swift
@@ -57,7 +57,7 @@ struct Generator: AsyncParsableCommand {
 
         // Parse semconv registry files
         let semConvModelsDirectory = semConvRepoDirectory.appending(path: "model/")
-        var parsedAttributes = try await parseAttributes(
+        var (groups, parsedAttributes) = try await parseAttributes(
             fileManager: fileManager,
             semConvModelsDirectory: semConvModelsDirectory
         )
@@ -102,6 +102,7 @@ struct Generator: AsyncParsableCommand {
             ]
         )
 
+        try generateDocumentationCatalog(context: context, groups: groups, repoDirectory: repoDirectory)
         try updateReadmeSemConvBadge(repoDirectory: repoDirectory)
     }
 
@@ -134,7 +135,11 @@ struct Generator: AsyncParsableCommand {
     }
 
     /// Checks cache, and if necessary downloads and unzips the semantic conventions repository
-    private func parseAttributes(fileManager: FileManager, semConvModelsDirectory: URL) async throws -> [Attribute] {
+    private func parseAttributes(
+        fileManager: FileManager,
+        semConvModelsDirectory: URL
+    ) async throws -> ([Group], [Attribute]) {
+        var groups = [Group]()
         var parsedAttributes = [Attribute]()
         for element in try fileManager.subpathsOfDirectory(atPath: semConvModelsDirectory.path()) {
             // Currently we only support parsing the `registry` files.
@@ -159,12 +164,13 @@ struct Generator: AsyncParsableCommand {
             }
 
             for group in file.groups {
+                groups.append(group)
                 for groupAttribute in group.attributes {
                     parsedAttributes.append(groupAttribute)
                 }
             }
         }
-        return parsedAttributes
+        return (groups, parsedAttributes)
     }
 
     /// Constructs a tree of namespaces from a list of attributes.
@@ -233,6 +239,89 @@ struct Generator: AsyncParsableCommand {
                 print("Wrote file \(filePath.path()).")
             }
         }
+    }
+
+    /// Generate the DocC documentation catalog given the generated symbols.
+    private func generateDocumentationCatalog(context: Context, groups: [Group], repoDirectory: URL) throws {
+        var indexPage = """
+            # ``OTelSemanticConventions``
+
+            OpenTelemetry semantic conventions for Swift.
+
+            @Metadata {
+                @DisplayName("OTel Semantic Conventions")
+                @PageColor(orange)
+                @Available(Swift, introduced: 6.1)
+            }
+
+            @Options {
+                @TopicsVisualStyle(hidden)
+            }
+            """
+
+        let groups = groups.sorted { $0.id.localizedStandardCompare($1.id) == .orderedAscending }
+
+        // render topics section
+
+        var attributesSection = "\n\n"
+        var topicsSection = "\n\n## Topics\n"
+
+        for group in groups {
+            var targetSymbols = [String: [String: String]]()
+            for attribute in group.attributes {
+                if let symbolReferences = context.doccSymbolReferences[attribute.id] {
+                    for (target, symbolReference) in symbolReferences.sorted(by: { $0.key < $1.key }) {
+                        targetSymbols[target, default: [:]][attribute.id] = symbolReference
+                    }
+                }
+            }
+
+            guard !targetSymbols.isEmpty else {
+                // ignore empty group
+                continue
+            }
+
+            attributesSection += "\n## \(group.documentationTopic)\n\n"
+            if let brief = group.brief {
+                attributesSection += "\(brief)\n"
+            }
+            attributesSection += "@TabNavigator {\n"
+
+            topicsSection += "\n### \(group.documentationTopic)\n\n"
+
+            for (target, symbols) in targetSymbols.sorted(by: {
+                $0.key.localizedStandardCompare($1.key) == .orderedAscending
+            }) {
+                attributesSection += """
+                        @Tab("\(target)") {
+                            @Links(visualStyle: list) { 
+
+                    """
+
+                for (_, symbol) in symbols.sorted(by: { $0.key.localizedStandardCompare($1.key) == .orderedAscending })
+                {
+                    attributesSection += "            - ``\(symbol)``\n"
+                    topicsSection += "- ``\(symbol)``\n"
+                }
+
+                attributesSection += "        }\n"
+                attributesSection += "    }\n"
+            }
+
+            attributesSection += "}\n"
+        }
+
+        indexPage += attributesSection
+        indexPage += topicsSection
+
+        let catalogDirectory = repoDirectory.appending(
+            components: "Sources",
+            "OTelSemanticConventions",
+            "Documentation.docc"
+        )
+        let indexPageURL = catalogDirectory.appending(path: "Documentation.md")
+        try (indexPage).write(to: indexPageURL, atomically: true, encoding: .utf8)
+        print("Generated DocC documentation catalog.")
     }
 
     /// Updates the README file with the new version of the semantic convention badge.

--- a/Generator/Sources/Generator.swift
+++ b/Generator/Sources/Generator.swift
@@ -89,7 +89,7 @@ struct Generator: AsyncParsableCommand {
             }
         }
 
-        let context = Context(rootNamespace: namespaceTree)
+        let context = Context(rootNamespace: namespaceTree, doccSymbolReferences: [:])
 
         // Generate individual target files
         try render(

--- a/Generator/Sources/RegistryFile.swift
+++ b/Generator/Sources/RegistryFile.swift
@@ -26,6 +26,10 @@ struct Group: Decodable {
     let brief: String?
     let attributes: [Attribute]
 
+    var documentationTopic: String {
+        display_name ?? id
+    }
+
     enum GroupType: String, Codable {
         case attribute_group
         case metric

--- a/Generator/Tests/RenderDeprecatedAttributeTests.swift
+++ b/Generator/Tests/RenderDeprecatedAttributeTests.swift
@@ -32,7 +32,8 @@ struct RenderDeprecatedAttributeTests {
                         ],
                     )
                 ]
-            )
+            ),
+            doccSymbolReferences: [:]
         )
     )
 

--- a/Sources/OTelSemanticConventions/Documentation.docc/Documentation.md
+++ b/Sources/OTelSemanticConventions/Documentation.docc/Documentation.md
@@ -1,0 +1,494 @@
+# ``OTelSemanticConventions``
+
+OpenTelemetry semantic conventions for Swift.
+
+@Metadata {
+    @DisplayName("OTel Semantic Conventions")
+    @PageColor(orange)
+    @Available(Swift, introduced: 6.1)
+}
+
+@Options {
+    @TopicsVisualStyle(hidden)
+}
+
+
+## Client Attributes
+
+These attributes may be used to describe the client in a connection-based network interaction where there is one side that initiates the connection (the client is the side that initiates the connection). This covers all TCP network interactions since TCP is connection-based and one side initiates the connection (an exception is made for peer-to-peer communication over TCP where the "user-facing" surface of the protocol / API doesn't expose a clear notion of client and server). This also covers UDP network interactions where one side initiates the interaction, e.g. QUIC (HTTP/3) and DNS.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ClientAttributes/NestedSpanAttributes/address``
+            - ``Tracing/SpanAttributes/ClientAttributes/NestedSpanAttributes/port``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/client/address``
+            - ``OTelAttribute/client/port``
+        }
+    }
+}
+
+## Code Attributes
+
+These attributes provide context about source code
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/CodeAttributes/ColumnAttributes/NestedSpanAttributes/number``
+            - ``Tracing/SpanAttributes/CodeAttributes/FileAttributes/NestedSpanAttributes/path``
+            - ``Tracing/SpanAttributes/CodeAttributes/FunctionAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/CodeAttributes/LineAttributes/NestedSpanAttributes/number``
+            - ``Tracing/SpanAttributes/CodeAttributes/NestedSpanAttributes/stacktrace``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/code/column/number``
+            - ``OTelAttribute/code/file/path``
+            - ``OTelAttribute/code/function/name``
+            - ``OTelAttribute/code/line/number``
+            - ``OTelAttribute/code/stacktrace``
+        }
+    }
+}
+
+## General Database Attributes
+
+This group defines the attributes used to describe telemetry in the context of databases.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/DbAttributes/CollectionAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/DbAttributes/NestedSpanAttributes/namespace``
+            - ``Tracing/SpanAttributes/DbAttributes/OperationAttributes/BatchAttributes/NestedSpanAttributes/size``
+            - ``Tracing/SpanAttributes/DbAttributes/OperationAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/DbAttributes/QueryAttributes/NestedSpanAttributes/summary``
+            - ``Tracing/SpanAttributes/DbAttributes/QueryAttributes/NestedSpanAttributes/text``
+            - ``Tracing/SpanAttributes/DbAttributes/ResponseAttributes/NestedSpanAttributes/statusCode``
+            - ``Tracing/SpanAttributes/DbAttributes/StoredProcedureAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/DbAttributes/SystemAttributes/NestedSpanAttributes/name``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/db/collection/name``
+            - ``OTelAttribute/db/namespace``
+            - ``OTelAttribute/db/operation/batch/size``
+            - ``OTelAttribute/db/operation/name``
+            - ``OTelAttribute/db/query/summary``
+            - ``OTelAttribute/db/query/text``
+            - ``OTelAttribute/db/response/statusCode``
+            - ``OTelAttribute/db/storedProcedure/name``
+            - ``OTelAttribute/db/system/name``
+        }
+    }
+}
+
+## Error Attributes
+
+This document defines the shared attributes used to report an error.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ErrorAttributes/NestedSpanAttributes/type``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/error/type``
+        }
+    }
+}
+
+## Exception Attributes
+
+This document defines the shared attributes used to report a single exception associated with a span or log.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/message``
+            - ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/stacktrace``
+            - ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/type``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/exception/message``
+            - ``OTelAttribute/exception/stacktrace``
+            - ``OTelAttribute/exception/type``
+        }
+    }
+}
+
+## Deprecated Exception Attributes
+
+Deprecated exception attributes.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/escaped``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/exception/escaped``
+        }
+    }
+}
+
+## HTTP Attributes
+
+This document defines semantic convention attributes in the HTTP namespace.
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/header``
+            - ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/method``
+            - ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/methodOriginal``
+            - ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/resendCount``
+            - ``Tracing/SpanAttributes/HttpAttributes/ResponseAttributes/header``
+            - ``Tracing/SpanAttributes/HttpAttributes/ResponseAttributes/NestedSpanAttributes/statusCode``
+            - ``Tracing/SpanAttributes/HttpAttributes/NestedSpanAttributes/route``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/http/request/header``
+            - ``OTelAttribute/http/request/method``
+            - ``OTelAttribute/http/request/methodOriginal``
+            - ``OTelAttribute/http/request/resendCount``
+            - ``OTelAttribute/http/response/header``
+            - ``OTelAttribute/http/response/statusCode``
+            - ``OTelAttribute/http/route``
+        }
+    }
+}
+
+## Network Attributes
+
+These attributes may be used for any network related operation.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/NetworkAttributes/LocalAttributes/NestedSpanAttributes/address``
+            - ``Tracing/SpanAttributes/NetworkAttributes/LocalAttributes/NestedSpanAttributes/port``
+            - ``Tracing/SpanAttributes/NetworkAttributes/PeerAttributes/NestedSpanAttributes/address``
+            - ``Tracing/SpanAttributes/NetworkAttributes/PeerAttributes/NestedSpanAttributes/port``
+            - ``Tracing/SpanAttributes/NetworkAttributes/ProtocolAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/NetworkAttributes/ProtocolAttributes/NestedSpanAttributes/version``
+            - ``Tracing/SpanAttributes/NetworkAttributes/NestedSpanAttributes/transport``
+            - ``Tracing/SpanAttributes/NetworkAttributes/NestedSpanAttributes/type``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/network/local/address``
+            - ``OTelAttribute/network/local/port``
+            - ``OTelAttribute/network/peer/address``
+            - ``OTelAttribute/network/peer/port``
+            - ``OTelAttribute/network/protocol/name``
+            - ``OTelAttribute/network/protocol/version``
+            - ``OTelAttribute/network/transport``
+            - ``OTelAttribute/network/type``
+        }
+    }
+}
+
+## OTel Attributes
+
+Attributes reserved for OpenTelemetry
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/OtelAttributes/NestedSpanAttributes/statusCode``
+            - ``Tracing/SpanAttributes/OtelAttributes/NestedSpanAttributes/statusDescription``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/otel/statusCode``
+            - ``OTelAttribute/otel/statusDescription``
+        }
+    }
+}
+
+## OTel Scope Attributes
+
+Attributes used by non-OTLP exporters to represent OpenTelemetry Scope's concepts.
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/OtelAttributes/ScopeAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/OtelAttributes/ScopeAttributes/NestedSpanAttributes/version``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/otel/scope/name``
+            - ``OTelAttribute/otel/scope/version``
+        }
+    }
+}
+
+## Server Attributes
+
+These attributes may be used to describe the server in a connection-based network interaction where there is one side that initiates the connection (the client is the side that initiates the connection). This covers all TCP network interactions since TCP is connection-based and one side initiates the connection (an exception is made for peer-to-peer communication over TCP where the "user-facing" surface of the protocol / API doesn't expose a clear notion of client and server). This also covers UDP network interactions where one side initiates the interaction, e.g. QUIC (HTTP/3) and DNS.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ServerAttributes/NestedSpanAttributes/address``
+            - ``Tracing/SpanAttributes/ServerAttributes/NestedSpanAttributes/port``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/server/address``
+            - ``OTelAttribute/server/port``
+        }
+    }
+}
+
+## Service Attributes
+
+A service instance.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/ServiceAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/ServiceAttributes/NestedSpanAttributes/version``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/service/name``
+            - ``OTelAttribute/service/version``
+        }
+    }
+}
+
+## Telemetry Attributes
+
+This document defines attributes for telemetry SDK.
+
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/language``
+            - ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/name``
+            - ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/version``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/telemetry/sdk/language``
+            - ``OTelAttribute/telemetry/sdk/name``
+            - ``OTelAttribute/telemetry/sdk/version``
+        }
+    }
+}
+
+## URL Attributes
+
+Attributes describing URL.
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/fragment``
+            - ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/full``
+            - ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/path``
+            - ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/query``
+            - ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/scheme``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/url/fragment``
+            - ``OTelAttribute/url/full``
+            - ``OTelAttribute/url/path``
+            - ``OTelAttribute/url/query``
+            - ``OTelAttribute/url/scheme``
+        }
+    }
+}
+
+## User-agent Attributes
+
+Describes user-agent attributes.
+@TabNavigator {
+    @Tab("Span Attributes") {
+        @Links(visualStyle: list) { 
+            - ``Tracing/SpanAttributes/UserAgentAttributes/NestedSpanAttributes/original``
+        }
+    }
+    @Tab("String Constants") {
+        @Links(visualStyle: list) { 
+            - ``OTelAttribute/userAgent/original``
+        }
+    }
+}
+
+
+## Topics
+
+### Client Attributes
+
+- ``Tracing/SpanAttributes/ClientAttributes/NestedSpanAttributes/address``
+- ``Tracing/SpanAttributes/ClientAttributes/NestedSpanAttributes/port``
+- ``OTelAttribute/client/address``
+- ``OTelAttribute/client/port``
+
+### Code Attributes
+
+- ``Tracing/SpanAttributes/CodeAttributes/ColumnAttributes/NestedSpanAttributes/number``
+- ``Tracing/SpanAttributes/CodeAttributes/FileAttributes/NestedSpanAttributes/path``
+- ``Tracing/SpanAttributes/CodeAttributes/FunctionAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/CodeAttributes/LineAttributes/NestedSpanAttributes/number``
+- ``Tracing/SpanAttributes/CodeAttributes/NestedSpanAttributes/stacktrace``
+- ``OTelAttribute/code/column/number``
+- ``OTelAttribute/code/file/path``
+- ``OTelAttribute/code/function/name``
+- ``OTelAttribute/code/line/number``
+- ``OTelAttribute/code/stacktrace``
+
+### General Database Attributes
+
+- ``Tracing/SpanAttributes/DbAttributes/CollectionAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/DbAttributes/NestedSpanAttributes/namespace``
+- ``Tracing/SpanAttributes/DbAttributes/OperationAttributes/BatchAttributes/NestedSpanAttributes/size``
+- ``Tracing/SpanAttributes/DbAttributes/OperationAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/DbAttributes/QueryAttributes/NestedSpanAttributes/summary``
+- ``Tracing/SpanAttributes/DbAttributes/QueryAttributes/NestedSpanAttributes/text``
+- ``Tracing/SpanAttributes/DbAttributes/ResponseAttributes/NestedSpanAttributes/statusCode``
+- ``Tracing/SpanAttributes/DbAttributes/StoredProcedureAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/DbAttributes/SystemAttributes/NestedSpanAttributes/name``
+- ``OTelAttribute/db/collection/name``
+- ``OTelAttribute/db/namespace``
+- ``OTelAttribute/db/operation/batch/size``
+- ``OTelAttribute/db/operation/name``
+- ``OTelAttribute/db/query/summary``
+- ``OTelAttribute/db/query/text``
+- ``OTelAttribute/db/response/statusCode``
+- ``OTelAttribute/db/storedProcedure/name``
+- ``OTelAttribute/db/system/name``
+
+### Error Attributes
+
+- ``Tracing/SpanAttributes/ErrorAttributes/NestedSpanAttributes/type``
+- ``OTelAttribute/error/type``
+
+### Exception Attributes
+
+- ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/message``
+- ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/stacktrace``
+- ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/type``
+- ``OTelAttribute/exception/message``
+- ``OTelAttribute/exception/stacktrace``
+- ``OTelAttribute/exception/type``
+
+### Deprecated Exception Attributes
+
+- ``Tracing/SpanAttributes/ExceptionAttributes/NestedSpanAttributes/escaped``
+- ``OTelAttribute/exception/escaped``
+
+### HTTP Attributes
+
+- ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/header``
+- ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/method``
+- ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/methodOriginal``
+- ``Tracing/SpanAttributes/HttpAttributes/RequestAttributes/NestedSpanAttributes/resendCount``
+- ``Tracing/SpanAttributes/HttpAttributes/ResponseAttributes/header``
+- ``Tracing/SpanAttributes/HttpAttributes/ResponseAttributes/NestedSpanAttributes/statusCode``
+- ``Tracing/SpanAttributes/HttpAttributes/NestedSpanAttributes/route``
+- ``OTelAttribute/http/request/header``
+- ``OTelAttribute/http/request/method``
+- ``OTelAttribute/http/request/methodOriginal``
+- ``OTelAttribute/http/request/resendCount``
+- ``OTelAttribute/http/response/header``
+- ``OTelAttribute/http/response/statusCode``
+- ``OTelAttribute/http/route``
+
+### Network Attributes
+
+- ``Tracing/SpanAttributes/NetworkAttributes/LocalAttributes/NestedSpanAttributes/address``
+- ``Tracing/SpanAttributes/NetworkAttributes/LocalAttributes/NestedSpanAttributes/port``
+- ``Tracing/SpanAttributes/NetworkAttributes/PeerAttributes/NestedSpanAttributes/address``
+- ``Tracing/SpanAttributes/NetworkAttributes/PeerAttributes/NestedSpanAttributes/port``
+- ``Tracing/SpanAttributes/NetworkAttributes/ProtocolAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/NetworkAttributes/ProtocolAttributes/NestedSpanAttributes/version``
+- ``Tracing/SpanAttributes/NetworkAttributes/NestedSpanAttributes/transport``
+- ``Tracing/SpanAttributes/NetworkAttributes/NestedSpanAttributes/type``
+- ``OTelAttribute/network/local/address``
+- ``OTelAttribute/network/local/port``
+- ``OTelAttribute/network/peer/address``
+- ``OTelAttribute/network/peer/port``
+- ``OTelAttribute/network/protocol/name``
+- ``OTelAttribute/network/protocol/version``
+- ``OTelAttribute/network/transport``
+- ``OTelAttribute/network/type``
+
+### OTel Attributes
+
+- ``Tracing/SpanAttributes/OtelAttributes/NestedSpanAttributes/statusCode``
+- ``Tracing/SpanAttributes/OtelAttributes/NestedSpanAttributes/statusDescription``
+- ``OTelAttribute/otel/statusCode``
+- ``OTelAttribute/otel/statusDescription``
+
+### OTel Scope Attributes
+
+- ``Tracing/SpanAttributes/OtelAttributes/ScopeAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/OtelAttributes/ScopeAttributes/NestedSpanAttributes/version``
+- ``OTelAttribute/otel/scope/name``
+- ``OTelAttribute/otel/scope/version``
+
+### Server Attributes
+
+- ``Tracing/SpanAttributes/ServerAttributes/NestedSpanAttributes/address``
+- ``Tracing/SpanAttributes/ServerAttributes/NestedSpanAttributes/port``
+- ``OTelAttribute/server/address``
+- ``OTelAttribute/server/port``
+
+### Service Attributes
+
+- ``Tracing/SpanAttributes/ServiceAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/ServiceAttributes/NestedSpanAttributes/version``
+- ``OTelAttribute/service/name``
+- ``OTelAttribute/service/version``
+
+### Telemetry Attributes
+
+- ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/language``
+- ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/name``
+- ``Tracing/SpanAttributes/TelemetryAttributes/SdkAttributes/NestedSpanAttributes/version``
+- ``OTelAttribute/telemetry/sdk/language``
+- ``OTelAttribute/telemetry/sdk/name``
+- ``OTelAttribute/telemetry/sdk/version``
+
+### URL Attributes
+
+- ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/fragment``
+- ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/full``
+- ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/path``
+- ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/query``
+- ``Tracing/SpanAttributes/UrlAttributes/NestedSpanAttributes/scheme``
+- ``OTelAttribute/url/fragment``
+- ``OTelAttribute/url/full``
+- ``OTelAttribute/url/path``
+- ``OTelAttribute/url/query``
+- ``OTelAttribute/url/scheme``
+
+### User-agent Attributes
+
+- ``Tracing/SpanAttributes/UserAgentAttributes/NestedSpanAttributes/original``
+- ``OTelAttribute/userAgent/original``

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+client.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+client.swift
@@ -49,7 +49,7 @@ extension SpanAttributes {
             ///     - `/tmp/my.sock`
             ///
             /// When observed from the server side, and when communicating through an intermediary, `client.address` SHOULD represent the client address behind any intermediaries,  for example proxies, if it's available.
-            public var address: Self.Key<String> { .init(name: OTelAttribute.client.address) }
+            public var address: SpanAttributeKey<String> { .init(name: OTelAttribute.client.address) }
 
             /// `client.port`: Client port number.
             ///
@@ -58,7 +58,7 @@ extension SpanAttributes {
             /// - Example: `65123`
             ///
             /// When observed from the server side, and when communicating through an intermediary, `client.port` SHOULD represent the client port behind any intermediaries,  for example proxies, if it's available.
-            public var port: Self.Key<Int> { .init(name: OTelAttribute.client.port) }
+            public var port: SpanAttributeKey<Int> { .init(name: OTelAttribute.client.port) }
         }
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+code.swift
@@ -45,7 +45,7 @@ extension SpanAttributes {
             /// - Type: string
             /// - Example: `at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
             /// `
-            public var stacktrace: Self.Key<String> { .init(name: OTelAttribute.code.stacktrace) }
+            public var stacktrace: SpanAttributeKey<String> { .init(name: OTelAttribute.code.stacktrace) }
         }
 
         /// `code.column` namespace
@@ -74,7 +74,7 @@ extension SpanAttributes {
                 /// - Stability: stable
                 /// - Type: int
                 /// - Example: `16`
-                public var number: Self.Key<Int> { .init(name: OTelAttribute.code.column.number) }
+                public var number: SpanAttributeKey<Int> { .init(name: OTelAttribute.code.column.number) }
             }
         }
 
@@ -104,7 +104,7 @@ extension SpanAttributes {
                 /// - Stability: stable
                 /// - Type: string
                 /// - Example: `/usr/local/MyApplication/content_root/app/index.php`
-                public var path: Self.Key<String> { .init(name: OTelAttribute.code.file.path) }
+                public var path: SpanAttributeKey<String> { .init(name: OTelAttribute.code.file.path) }
             }
         }
 
@@ -153,7 +153,7 @@ extension SpanAttributes {
                 /// * Erlang: `opentelemetry_ctx:new`
                 /// * Rust: `playground::my_module::my_cool_func`
                 /// * C function: `fopen`
-                public var name: Self.Key<String> { .init(name: OTelAttribute.code.function.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.code.function.name) }
             }
         }
 
@@ -183,7 +183,7 @@ extension SpanAttributes {
                 /// - Stability: stable
                 /// - Type: int
                 /// - Example: `42`
-                public var number: Self.Key<Int> { .init(name: OTelAttribute.code.line.number) }
+                public var number: SpanAttributeKey<Int> { .init(name: OTelAttribute.code.line.number) }
             }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+db.swift
@@ -50,7 +50,7 @@ extension SpanAttributes {
             /// If a database system has multiple namespace components, they SHOULD be concatenated from the most general to the most specific namespace component, using `|` as a separator between the components. Any missing components (and their associated separators) SHOULD be omitted.
             /// Semantic conventions for individual database systems SHOULD document what `db.namespace` means in the context of that system.
             /// It is RECOMMENDED to capture the value as provided by the application without attempting to do any case normalization.
-            public var namespace: Self.Key<String> { .init(name: OTelAttribute.db.namespace) }
+            public var namespace: SpanAttributeKey<String> { .init(name: OTelAttribute.db.namespace) }
         }
 
         /// `db.collection` namespace
@@ -91,7 +91,7 @@ extension SpanAttributes {
                 ///
                 /// For batch operations, if the individual operations are known to have the same
                 /// collection name then that collection name SHOULD be used.
-                public var name: Self.Key<String> { .init(name: OTelAttribute.db.collection.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.db.collection.name) }
             }
         }
 
@@ -139,7 +139,7 @@ extension SpanAttributes {
                 /// then that operation name SHOULD be used prepended by `BATCH `,
                 /// otherwise `db.operation.name` SHOULD be `BATCH` or some other database
                 /// system specific term if more applicable.
-                public var name: Self.Key<String> { .init(name: OTelAttribute.db.operation.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.db.operation.name) }
             }
 
             /// `db.operation.batch` namespace
@@ -173,7 +173,7 @@ extension SpanAttributes {
                     ///     - `4`
                     ///
                     /// Operations are only considered batches when they contain two or more operations, and so `db.operation.batch.size` SHOULD never be `1`.
-                    public var size: Self.Key<Int> { .init(name: OTelAttribute.db.operation.batch.size) }
+                    public var size: SpanAttributeKey<Int> { .init(name: OTelAttribute.db.operation.batch.size) }
                 }
             }
         }
@@ -217,7 +217,7 @@ extension SpanAttributes {
                 /// that support query parsing SHOULD generate a summary following
                 /// [Generating query summary](/docs/database/database-spans.md#generating-a-summary-of-the-query)
                 /// section.
-                public var summary: Self.Key<String> { .init(name: OTelAttribute.db.query.summary) }
+                public var summary: SpanAttributeKey<String> { .init(name: OTelAttribute.db.query.summary) }
 
                 /// `db.query.text`: The database query being executed.
                 ///
@@ -230,7 +230,7 @@ extension SpanAttributes {
                 /// For sanitization see [Sanitization of `db.query.text`](/docs/database/database-spans.md#sanitization-of-dbquerytext).
                 /// For batch operations, if the individual operations are known to have the same query text then that query text SHOULD be used, otherwise all of the individual query texts SHOULD be concatenated with separator `; ` or some other database system specific separator if more applicable.
                 /// Parameterized query text SHOULD NOT be sanitized. Even though parameterized query text can potentially have sensitive data, by using a parameterized query the user is giving a strong signal that any sensitive data will be passed as parameter values, and the benefit to observability of capturing the static part of the query text by default outweighs the risk.
-                public var text: Self.Key<String> { .init(name: OTelAttribute.db.query.text) }
+                public var text: SpanAttributeKey<String> { .init(name: OTelAttribute.db.query.text) }
             }
         }
 
@@ -267,7 +267,7 @@ extension SpanAttributes {
                 ///
                 /// The status code returned by the database. Usually it represents an error code, but may also represent partial success, warning, or differentiate between various types of successful outcomes.
                 /// Semantic conventions for individual database systems SHOULD document what `db.response.status_code` means in the context of that system.
-                public var statusCode: Self.Key<String> { .init(name: OTelAttribute.db.response.statusCode) }
+                public var statusCode: SpanAttributeKey<String> { .init(name: OTelAttribute.db.response.statusCode) }
             }
         }
 
@@ -303,7 +303,7 @@ extension SpanAttributes {
                 ///
                 /// For batch operations, if the individual operations are known to have the same
                 /// stored procedure name then that stored procedure name SHOULD be used.
-                public var name: Self.Key<String> { .init(name: OTelAttribute.db.storedProcedure.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.db.storedProcedure.name) }
             }
         }
 
@@ -375,7 +375,7 @@ extension SpanAttributes {
                 ///     - `trino`: [Trino](https://trino.io/)
                 ///
                 /// The actual DBMS may differ from the one identified by the client. For example, when using PostgreSQL client libraries to connect to a CockroachDB, the `db.system.name` is set to `postgresql` based on the instrumentation's best knowledge.
-                public var name: Self.Key<NameEnum> { .init(name: OTelAttribute.db.system.name) }
+                public var name: SpanAttributeKey<NameEnum> { .init(name: OTelAttribute.db.system.name) }
 
                 public struct NameEnum: SpanAttributeConvertible, Sendable {
                     private let rawValue: String

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+error.swift
@@ -69,7 +69,7 @@ extension SpanAttributes {
             ///
             /// - Use a domain-specific attribute
             /// - Set `error.type` to capture all errors, regardless of whether they are defined within the domain-specific set or not.
-            public var `type`: Self.Key<TypeEnum> { .init(name: OTelAttribute.error.`type`) }
+            public var `type`: SpanAttributeKey<TypeEnum> { .init(name: OTelAttribute.error.`type`) }
 
             public struct TypeEnum: SpanAttributeConvertible, Sendable {
                 private let rawValue: String

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+exception.swift
@@ -49,7 +49,7 @@ extension SpanAttributes {
                 message:
                     "Obsoleted: It's no longer recommended to record exceptions that are handled and do not escape the scope of a span."
             )
-            public var escaped: Self.Key<Bool> { .init(name: OTelAttribute.exception.escaped) }
+            public var escaped: SpanAttributeKey<Bool> { .init(name: OTelAttribute.exception.escaped) }
 
             /// `exception.message`: The exception message.
             ///
@@ -58,7 +58,7 @@ extension SpanAttributes {
             /// - Examples:
             ///     - `Division by zero`
             ///     - `Can't convert 'int' object to str implicitly`
-            public var message: Self.Key<String> { .init(name: OTelAttribute.exception.message) }
+            public var message: SpanAttributeKey<String> { .init(name: OTelAttribute.exception.message) }
 
             /// `exception.stacktrace`: A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG.
             ///
@@ -66,7 +66,7 @@ extension SpanAttributes {
             /// - Type: string
             /// - Example: `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)
             /// `
-            public var stacktrace: Self.Key<String> { .init(name: OTelAttribute.exception.stacktrace) }
+            public var stacktrace: SpanAttributeKey<String> { .init(name: OTelAttribute.exception.stacktrace) }
 
             /// `exception.type`: The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it.
             ///
@@ -75,7 +75,7 @@ extension SpanAttributes {
             /// - Examples:
             ///     - `java.net.ConnectException`
             ///     - `OSError`
-            public var `type`: Self.Key<String> { .init(name: OTelAttribute.exception.`type`) }
+            public var `type`: SpanAttributeKey<String> { .init(name: OTelAttribute.exception.`type`) }
         }
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+http.swift
@@ -49,7 +49,7 @@ extension SpanAttributes {
             ///
             /// MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
             /// SHOULD include the [application root](/docs/http/http-spans.md#http-server-definitions) if there is one.
-            public var route: Self.Key<String> { .init(name: OTelAttribute.http.route) }
+            public var route: SpanAttributeKey<String> { .init(name: OTelAttribute.http.route) }
         }
 
         /// `http.request` namespace
@@ -165,7 +165,7 @@ extension SpanAttributes {
                 /// HTTP method names are case-sensitive and `http.request.method` attribute value MUST match a known HTTP method name exactly.
                 /// Instrumentations for specific web frameworks that consider HTTP methods to be case insensitive, SHOULD populate a canonical equivalent.
                 /// Tracing instrumentations that do so, MUST also set `http.request.method_original` to the original value.
-                public var method: Self.Key<MethodEnum> { .init(name: OTelAttribute.http.request.method) }
+                public var method: SpanAttributeKey<MethodEnum> { .init(name: OTelAttribute.http.request.method) }
 
                 public struct MethodEnum: SpanAttributeConvertible, Sendable {
                     private let rawValue: String
@@ -202,7 +202,9 @@ extension SpanAttributes {
                 ///     - `GeT`
                 ///     - `ACL`
                 ///     - `foo`
-                public var methodOriginal: Self.Key<String> { .init(name: OTelAttribute.http.request.methodOriginal) }
+                public var methodOriginal: SpanAttributeKey<String> {
+                    .init(name: OTelAttribute.http.request.methodOriginal)
+                }
 
                 /// `http.request.resend_count`: The ordinal number of request resending attempt (for any reason, including redirects).
                 ///
@@ -211,7 +213,7 @@ extension SpanAttributes {
                 /// - Example: `3`
                 ///
                 /// The resend count SHOULD be updated each time an HTTP request gets resent by the client, regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503 Server Unavailable, network issues, or any other).
-                public var resendCount: Self.Key<Int> { .init(name: OTelAttribute.http.request.resendCount) }
+                public var resendCount: SpanAttributeKey<Int> { .init(name: OTelAttribute.http.request.resendCount) }
             }
         }
 
@@ -299,7 +301,7 @@ extension SpanAttributes {
                 /// - Stability: stable
                 /// - Type: int
                 /// - Example: `200`
-                public var statusCode: Self.Key<Int> { .init(name: OTelAttribute.http.response.statusCode) }
+                public var statusCode: SpanAttributeKey<Int> { .init(name: OTelAttribute.http.response.statusCode) }
             }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+network.swift
@@ -57,7 +57,7 @@ extension SpanAttributes {
             /// Consider always setting the transport when setting a port number, since
             /// a port number is ambiguous without knowing the transport. For example
             /// different processes could be listening on TCP port 12345 and UDP port 12345.
-            public var transport: Self.Key<TransportEnum> { .init(name: OTelAttribute.network.transport) }
+            public var transport: SpanAttributeKey<TransportEnum> { .init(name: OTelAttribute.network.transport) }
 
             public struct TransportEnum: SpanAttributeConvertible, Sendable {
                 private let rawValue: String
@@ -87,7 +87,7 @@ extension SpanAttributes {
             ///     - `ipv6`
             ///
             /// The value SHOULD be normalized to lowercase.
-            public var `type`: Self.Key<TypeEnum> { .init(name: OTelAttribute.network.`type`) }
+            public var `type`: SpanAttributeKey<TypeEnum> { .init(name: OTelAttribute.network.`type`) }
 
             public struct TypeEnum: SpanAttributeConvertible, Sendable {
                 private let rawValue: String
@@ -129,14 +129,14 @@ extension SpanAttributes {
                 /// - Examples:
                 ///     - `10.1.2.80`
                 ///     - `/tmp/my.sock`
-                public var address: Self.Key<String> { .init(name: OTelAttribute.network.local.address) }
+                public var address: SpanAttributeKey<String> { .init(name: OTelAttribute.network.local.address) }
 
                 /// `network.local.port`: Local port number of the network connection.
                 ///
                 /// - Stability: stable
                 /// - Type: int
                 /// - Example: `65123`
-                public var port: Self.Key<Int> { .init(name: OTelAttribute.network.local.port) }
+                public var port: SpanAttributeKey<Int> { .init(name: OTelAttribute.network.local.port) }
             }
         }
 
@@ -168,14 +168,14 @@ extension SpanAttributes {
                 /// - Examples:
                 ///     - `10.1.2.80`
                 ///     - `/tmp/my.sock`
-                public var address: Self.Key<String> { .init(name: OTelAttribute.network.peer.address) }
+                public var address: SpanAttributeKey<String> { .init(name: OTelAttribute.network.peer.address) }
 
                 /// `network.peer.port`: Peer port number of the network connection.
                 ///
                 /// - Stability: stable
                 /// - Type: int
                 /// - Example: `65123`
-                public var port: Self.Key<Int> { .init(name: OTelAttribute.network.peer.port) }
+                public var port: SpanAttributeKey<Int> { .init(name: OTelAttribute.network.peer.port) }
             }
         }
 
@@ -210,7 +210,7 @@ extension SpanAttributes {
                 ///     - `mqtt`
                 ///
                 /// The value SHOULD be normalized to lowercase.
-                public var name: Self.Key<String> { .init(name: OTelAttribute.network.`protocol`.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.network.`protocol`.name) }
 
                 /// `network.protocol.version`: The actual version of the protocol used for network communication.
                 ///
@@ -221,7 +221,7 @@ extension SpanAttributes {
                 ///     - `2`
                 ///
                 /// If protocol version is subject to negotiation (for example using [ALPN](https://www.rfc-editor.org/rfc/rfc7301.html)), this attribute SHOULD be set to the negotiated version. If the actual protocol version is not known, this attribute SHOULD NOT be set.
-                public var version: Self.Key<String> { .init(name: OTelAttribute.network.`protocol`.version) }
+                public var version: SpanAttributeKey<String> { .init(name: OTelAttribute.network.`protocol`.version) }
             }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+otel.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+otel.swift
@@ -45,7 +45,7 @@ extension SpanAttributes {
             /// - Type: enum
             ///     - `OK`: The operation has been validated by an Application developer or Operator to have completed successfully.
             ///     - `ERROR`: The operation contains an error.
-            public var statusCode: Self.Key<StatusCodeEnum> { .init(name: OTelAttribute.otel.statusCode) }
+            public var statusCode: SpanAttributeKey<StatusCodeEnum> { .init(name: OTelAttribute.otel.statusCode) }
 
             public struct StatusCodeEnum: SpanAttributeConvertible, Sendable {
                 private let rawValue: String
@@ -63,7 +63,7 @@ extension SpanAttributes {
             /// - Stability: stable
             /// - Type: string
             /// - Example: `resource not found`
-            public var statusDescription: Self.Key<String> { .init(name: OTelAttribute.otel.statusDescription) }
+            public var statusDescription: SpanAttributeKey<String> { .init(name: OTelAttribute.otel.statusDescription) }
         }
 
         /// `otel.scope` namespace
@@ -92,14 +92,14 @@ extension SpanAttributes {
                 /// - Stability: stable
                 /// - Type: string
                 /// - Example: `io.opentelemetry.contrib.mongodb`
-                public var name: Self.Key<String> { .init(name: OTelAttribute.otel.scope.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.otel.scope.name) }
 
                 /// `otel.scope.version`: The version of the instrumentation scope - (`InstrumentationScope.Version` in OTLP).
                 ///
                 /// - Stability: stable
                 /// - Type: string
                 /// - Example: `1.0.0`
-                public var version: Self.Key<String> { .init(name: OTelAttribute.otel.scope.version) }
+                public var version: SpanAttributeKey<String> { .init(name: OTelAttribute.otel.scope.version) }
             }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+server.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+server.swift
@@ -49,7 +49,7 @@ extension SpanAttributes {
             ///     - `/tmp/my.sock`
             ///
             /// When observed from the client side, and when communicating through an intermediary, `server.address` SHOULD represent the server address behind any intermediaries, for example proxies, if it's available.
-            public var address: Self.Key<String> { .init(name: OTelAttribute.server.address) }
+            public var address: SpanAttributeKey<String> { .init(name: OTelAttribute.server.address) }
 
             /// `server.port`: Server port number.
             ///
@@ -61,7 +61,7 @@ extension SpanAttributes {
             ///     - `443`
             ///
             /// When observed from the client side, and when communicating through an intermediary, `server.port` SHOULD represent the server port behind any intermediaries, for example proxies, if it's available.
-            public var port: Self.Key<Int> { .init(name: OTelAttribute.server.port) }
+            public var port: SpanAttributeKey<Int> { .init(name: OTelAttribute.server.port) }
         }
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+service.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+service.swift
@@ -46,7 +46,7 @@ extension SpanAttributes {
             /// - Example: `shoppingcart`
             ///
             /// MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
-            public var name: Self.Key<String> { .init(name: OTelAttribute.service.name) }
+            public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.service.name) }
 
             /// `service.version`: The version string of the service API or implementation. The format is not defined by these conventions.
             ///
@@ -55,7 +55,7 @@ extension SpanAttributes {
             /// - Examples:
             ///     - `2.0.0`
             ///     - `a01dbef8a`
-            public var version: Self.Key<String> { .init(name: OTelAttribute.service.version) }
+            public var version: SpanAttributeKey<String> { .init(name: OTelAttribute.service.version) }
         }
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+telemetry.swift
@@ -77,7 +77,9 @@ extension SpanAttributes {
                 ///     - `rust`
                 ///     - `swift`
                 ///     - `webjs`
-                public var language: Self.Key<LanguageEnum> { .init(name: OTelAttribute.telemetry.sdk.language) }
+                public var language: SpanAttributeKey<LanguageEnum> {
+                    .init(name: OTelAttribute.telemetry.sdk.language)
+                }
 
                 public struct LanguageEnum: SpanAttributeConvertible, Sendable {
                     private let rawValue: String
@@ -122,14 +124,14 @@ extension SpanAttributes {
                 /// or another suitable identifier depending on the language.
                 /// The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
                 /// All custom identifiers SHOULD be stable across different versions of an implementation.
-                public var name: Self.Key<String> { .init(name: OTelAttribute.telemetry.sdk.name) }
+                public var name: SpanAttributeKey<String> { .init(name: OTelAttribute.telemetry.sdk.name) }
 
                 /// `telemetry.sdk.version`: The version string of the telemetry SDK.
                 ///
                 /// - Stability: stable
                 /// - Type: string
                 /// - Example: `1.2.3`
-                public var version: Self.Key<String> { .init(name: OTelAttribute.telemetry.sdk.version) }
+                public var version: SpanAttributeKey<String> { .init(name: OTelAttribute.telemetry.sdk.version) }
             }
         }
     }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+url.swift
@@ -44,7 +44,7 @@ extension SpanAttributes {
             /// - Stability: stable
             /// - Type: string
             /// - Example: `SemConv`
-            public var fragment: Self.Key<String> { .init(name: OTelAttribute.url.fragment) }
+            public var fragment: SpanAttributeKey<String> { .init(name: OTelAttribute.url.fragment) }
 
             /// `url.full`: Absolute URL describing a network resource according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986)
             ///
@@ -77,7 +77,7 @@ extension SpanAttributes {
             ///
             /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
             /// `https://www.example.com/path?color=blue&sig=REDACTED`.
-            public var full: Self.Key<String> { .init(name: OTelAttribute.url.full) }
+            public var full: SpanAttributeKey<String> { .init(name: OTelAttribute.url.full) }
 
             /// `url.path`: The [URI path](https://www.rfc-editor.org/rfc/rfc3986#section-3.3) component
             ///
@@ -86,7 +86,7 @@ extension SpanAttributes {
             /// - Example: `/search`
             ///
             /// Sensitive content provided in `url.path` SHOULD be scrubbed when instrumentations can identify it.
-            public var path: Self.Key<String> { .init(name: OTelAttribute.url.path) }
+            public var path: SpanAttributeKey<String> { .init(name: OTelAttribute.url.path) }
 
             /// `url.query`: The [URI query](https://www.rfc-editor.org/rfc/rfc3986#section-3.4) component
             ///
@@ -108,7 +108,7 @@ extension SpanAttributes {
             ///
             /// When a query string value is redacted, the query string key SHOULD still be preserved, e.g.
             /// `q=OpenTelemetry&sig=REDACTED`.
-            public var query: Self.Key<String> { .init(name: OTelAttribute.url.query) }
+            public var query: SpanAttributeKey<String> { .init(name: OTelAttribute.url.query) }
 
             /// `url.scheme`: The [URI scheme](https://www.rfc-editor.org/rfc/rfc3986#section-3.1) component identifying the used protocol.
             ///
@@ -118,7 +118,7 @@ extension SpanAttributes {
             ///     - `https`
             ///     - `ftp`
             ///     - `telnet`
-            public var scheme: Self.Key<String> { .init(name: OTelAttribute.url.scheme) }
+            public var scheme: SpanAttributeKey<String> { .init(name: OTelAttribute.url.scheme) }
         }
     }
 }

--- a/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+userAgent.swift
+++ b/Sources/OTelSemanticConventions/Generated/Tracing/SpanAttributes+userAgent.swift
@@ -47,7 +47,7 @@ extension SpanAttributes {
             ///     - `CERN-LineMode/2.15 libwww/2.17b3`
             ///     - `Mozilla/5.0 (iPhone; CPU iPhone OS 14_7_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1`
             ///     - `YourApp/1.0.0 grpc-java-okhttp/1.27.2`
-            public var original: Self.Key<String> { .init(name: OTelAttribute.userAgent.original) }
+            public var original: SpanAttributeKey<String> { .init(name: OTelAttribute.userAgent.original) }
         }
     }
 }


### PR DESCRIPTION
This PR adds DocC documentation catalog generating to the `Generator`. The catalog currently consists of an index page that groups symbols into their root namespaces. The index page also shows a tab navigator for each group to switch between "String Constants" and "Span Attributes".

- Closes #21

## Screenshots

_Span Attributes tab selected_
![Span Attributes](https://github.com/user-attachments/assets/a04ad6cc-c5ea-48e6-ace4-07bca97544c3)

_String Constants tab selected_
![String Constants](https://github.com/user-attachments/assets/01c92d11-f6da-4dac-bcd9-c1b2f8ba61e1)