### PR TITLE
Updates to semconv v1.36

### DIFF
--- a/Generator/Sources/Generator.swift
+++ b/Generator/Sources/Generator.swift
@@ -64,7 +64,7 @@ struct Generator: AsyncParsableCommand {
 
         // Filter out attributes that are not stable
         parsedAttributes = parsedAttributes.filter { attribute in
-            attribute.stability != .development && attribute.stability != .experimental
+            attribute.stability == .stable
         }
 
         // Create semconv namespace tree

--- a/README.md
+++ b/README.md
@@ -82,5 +82,5 @@ However, this package uses a Swift generator instead for the following reasons:
 - To support the desired API where Swift usage nests namespaces with the `.` notation just like the attributes, a namespace tree must be constructed and traversed. Doing this in the Weaver Jinja templating language is difficult.
 - Swift will be more familiar than Jinja templates to users of this package, leading to easier maintenance.
 
-[semconv-badge]: https://img.shields.io/badge/semconv-1.34.0-blue.svg
+[semconv-badge]: https://img.shields.io/badge/semconv-1.36.0-blue.svg
 [semconv-url]: https://github.com/open-telemetry/semantic-conventions.git


### PR DESCRIPTION
This generates semconv v1.36. There are no stable changes, so it just updates the badge in the readme.

It also includes an adjustment to not include `release_candidate` stability attributes.